### PR TITLE
feature/1252 Manuell endring av vedtaksperiode og standard begrunnelser

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/BrevSøknadInnvilgetDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/pdfgen/BrevSøknadInnvilgetDTO.kt
@@ -22,6 +22,7 @@ private class BrevFørstegangsvedtakInnvilgelseDTO(
     val datoForUtsending: String,
     val sats: Int,
     val satsBarn: Int,
+    val tilleggstekst: String? = null,
 )
 
 internal suspend fun Rammevedtak.toInnvilgetSøknadsbrev(
@@ -53,5 +54,6 @@ internal suspend fun Rammevedtak.toInnvilgetSøknadsbrev(
         datoForUtsending = vedtaksdato.format(norskDatoFormatter),
         sats = Satser.sats(periode.fraOgMed).sats,
         satsBarn = Satser.sats(periode.fraOgMed).satsBarnetillegg,
+        tilleggstekst = this.behandling.tilleggstekstBrev?.tekst,
     ).let { serialize(it) }
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/BehandlingPostgresRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/BehandlingPostgresRepo.kt
@@ -175,6 +175,7 @@ class BehandlingPostgresRepo(
                             "sendt_til_beslutning" to behandling.sendtTilBeslutning,
                             "sendt_til_datadeling" to behandling.sendtTilDatadeling,
                             "behandlingstype" to behandling.behandlingstype.toDbValue(),
+                            "tilleggstekst_brev" to behandling.tilleggstekstBrev?.toDbJson(),
                         ),
                     ).asUpdate,
                 )
@@ -209,6 +210,7 @@ class BehandlingPostgresRepo(
                         "sendt_til_datadeling" to behandling.sendtTilDatadeling,
                         "sist_endret" to behandling.sistEndret,
                         "behandlingstype" to behandling.behandlingstype.toDbValue(),
+                        "tilleggstekst_brev" to behandling.tilleggstekstBrev?.toDbJson(),
                     ),
                 ).asUpdate,
             )
@@ -247,6 +249,7 @@ class BehandlingPostgresRepo(
             val opprettet = localDateTime("opprettet")
             val iverksattTidspunkt = localDateTimeOrNull("iverksatt_tidspunkt")
             val sistEndret = localDateTime("sist_endret")
+            val tilleggstekstBrev = stringOrNull("tilleggstekst_brev")?.toTilleggstekstBrev()
             return Behandling(
                 id = id,
                 sakId = sakId,
@@ -266,6 +269,7 @@ class BehandlingPostgresRepo(
                 sendtTilDatadeling = localDateTimeOrNull("sendt_til_datadeling"),
                 sistEndret = sistEndret,
                 behandlingstype = string("behandlingstype").toBehandlingstype(),
+                tilleggstekstBrev = tilleggstekstBrev,
             )
         }
 
@@ -288,7 +292,8 @@ class BehandlingPostgresRepo(
                 iverksatt_tidspunkt,
                 sendt_til_beslutning,
                 sendt_til_datadeling,
-                behandlingstype
+                behandlingstype,
+                tilleggstekst_brev
             ) values (
                 :id,
                 :sak_id,
@@ -305,7 +310,8 @@ class BehandlingPostgresRepo(
                 :iverksatt_tidspunkt,
                 :sendt_til_beslutning,
                 :sendt_til_datadeling,
-                :behandlingstype
+                :behandlingstype,
+                to_jsonb(:tilleggstekst_brev::jsonb)
             )
             """.trimIndent()
 
@@ -326,7 +332,8 @@ class BehandlingPostgresRepo(
                 iverksatt_tidspunkt = :iverksatt_tidspunkt,
                 sendt_til_beslutning = :sendt_til_beslutning,
                 sendt_til_datadeling = :sendt_til_datadeling,
-                behandlingstype = :behandlingstype
+                behandlingstype = :behandlingstype,
+                tilleggstekst_brev = to_jsonb(:tilleggstekst_brev::jsonb)
             where id = :id
               and sist_endret = :sist_endret_old
             """.trimIndent()

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/SubsumsjonDb.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/SubsumsjonDb.kt
@@ -1,0 +1,17 @@
+package no.nav.tiltakspenger.vedtak.repository.behandling
+
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
+
+enum class SubsumsjonDb {
+    TILTAKSDELTAGELSE,
+}
+
+fun SubsumsjonDb.toDomain(): TilleggstekstBrev.Subsumsjon =
+    when (this) {
+        SubsumsjonDb.TILTAKSDELTAGELSE -> TilleggstekstBrev.Subsumsjon.TILTAKSDELTAGELSE
+    }
+
+fun TilleggstekstBrev.Subsumsjon.toDb(): SubsumsjonDb =
+    when (this) {
+        TilleggstekstBrev.Subsumsjon.TILTAKSDELTAGELSE -> SubsumsjonDb.TILTAKSDELTAGELSE
+    }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/TilleggstekstBrevDbJson.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/TilleggstekstBrevDbJson.kt
@@ -1,0 +1,31 @@
+package no.nav.tiltakspenger.vedtak.repository.behandling
+
+import no.nav.tiltakspenger.libs.json.deserialize
+import no.nav.tiltakspenger.libs.json.serialize
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
+import java.security.InvalidParameterException
+
+data class TilleggstekstBrevDbJson(
+    val subsumsjon: SubsumsjonDb,
+    val tekst: String,
+)
+
+internal fun String.toTilleggstekstBrev(): TilleggstekstBrev =
+    try {
+        val tilleggstekstBrevJson = deserialize<TilleggstekstBrevDbJson>(this)
+
+        TilleggstekstBrev(
+            subsumsjon = tilleggstekstBrevJson.subsumsjon.toDomain(),
+            tekst = tilleggstekstBrevJson.tekst,
+        )
+    } catch (exception: Exception) {
+        throw InvalidParameterException("Det oppstod en feil ved parsing av json: " + exception.message)
+    }
+
+internal fun TilleggstekstBrev.toDbJson(): String =
+    serialize(
+        TilleggstekstBrevDbJson(
+            subsumsjon = subsumsjon.toDb(),
+            tekst = tekst,
+        ),
+    )

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingDTO.kt
@@ -21,6 +21,8 @@ internal data class BehandlingDTO(
     val vilkårssett: VilkårssettDTO,
     val stønadsdager: StønadsdagerDTO,
     val attesteringer: List<AttesteringDTO>,
+    val tilleggstekstBrev: TilleggstekstBrevDTO?,
+    val kreverBegrunnelse: Boolean,
 )
 
 internal fun Behandling.toDTO() =
@@ -36,4 +38,6 @@ internal fun Behandling.toDTO() =
         vilkårssett = this.vilkårssett.toDTO(),
         stønadsdager = this.stønadsdager.toDTO(),
         behandlingstype = behandlingstype,
+        tilleggstekstBrev = this.tilleggstekstBrev?.toDTO(),
+        kreverBegrunnelse = this.erBegrunnelsePåkrevd,
     )

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingRoutes.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/BehandlingRoutes.kt
@@ -8,6 +8,15 @@ import io.ktor.server.routing.post
 import mu.KotlinLogging
 import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.common.BehandlingId
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.periodisering.PeriodeDTO
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeOppdatereTilleggstekstBrev
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeOppdatereVurderingsperiode
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterTilleggstekstBrevKommando
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterVurderingsperiodeKommando
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
 import no.nav.tiltakspenger.saksbehandling.service.behandling.BehandlingService
 import no.nav.tiltakspenger.saksbehandling.service.behandling.vilkår.kvp.KvpVilkårService
 import no.nav.tiltakspenger.saksbehandling.service.behandling.vilkår.livsopphold.LivsoppholdVilkårService
@@ -25,13 +34,52 @@ import no.nav.tiltakspenger.vedtak.routes.behandling.vilkår.kvp.kvpRoutes
 import no.nav.tiltakspenger.vedtak.routes.behandling.vilkår.livsopphold.livsoppholdRoutes
 import no.nav.tiltakspenger.vedtak.routes.behandling.vilkår.tiltakdeltagelse.tiltakDeltagelseRoutes
 import no.nav.tiltakspenger.vedtak.routes.correlationId
+import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.Standardfeil.behandlingKanIkkeVæreSendtTilBeslutterEllerVedtatt
+import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.Standardfeil.ikkeTilgang
 import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.Standardfeil.måVæreSaksbehandler
 import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.Standardfeil.måVæreSaksbehandlerEllerBeslutter
+import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.Standardfeil.nyPeriodeMåVæreInnenforVurderingsperiode
+import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.respond400BadRequest
 import no.nav.tiltakspenger.vedtak.routes.exceptionhandling.respond403Forbidden
 import no.nav.tiltakspenger.vedtak.routes.withBehandlingId
+import no.nav.tiltakspenger.vedtak.routes.withBody
 
 internal const val BEHANDLING_PATH = "/behandling"
 internal const val BEHANDLINGER_PATH = "/behandlinger"
+
+private data class OppdaterVurderingsPeriodeBody(
+    val periode: PeriodeDTO,
+) {
+    fun tilKommando(
+        behandlingId: BehandlingId,
+        correlationId: CorrelationId,
+        saksbehandler: Saksbehandler,
+    ): OppdaterVurderingsperiodeKommando {
+        return OppdaterVurderingsperiodeKommando(
+            behandlingId = behandlingId,
+            correlationId = correlationId,
+            saksbehandler = saksbehandler,
+            periode = periode.toDomain(),
+        )
+    }
+}
+
+private data class OppdaterSubsumsjonBody(
+    val subsumsjon: TilleggstekstBrev.Subsumsjon,
+) {
+    fun tilKommando(
+        behandlingId: BehandlingId,
+        correlationId: CorrelationId,
+        saksbehandler: Saksbehandler,
+    ): OppdaterTilleggstekstBrevKommando {
+        return OppdaterTilleggstekstBrevKommando(
+            behandlingId = behandlingId,
+            correlationId = correlationId,
+            saksbehandler = saksbehandler,
+            subsumsjon = subsumsjon,
+        )
+    }
+}
 
 fun Route.behandlingRoutes(
     behandlingService: BehandlingService,
@@ -87,6 +135,92 @@ fun Route.behandlingRoutes(
                         call.respond(status = HttpStatusCode.OK, message = "{}")
                     },
                 )
+            }
+        }
+    }
+
+    post("$BEHANDLING_PATH/{behandlingId}/tilleggstekst") {
+        logger.debug("Mottatt post-request på '$BEHANDLING_PATH/{behandlingId}/tilleggstekst' - oppdaterer tilleggstekst for brev")
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withBehandlingId { behandlingId ->
+                val correlationId = call.correlationId()
+                call.withBody<OppdaterSubsumsjonBody> { body ->
+                    behandlingService.oppdaterTilleggstekstBrevPåBehandling(
+                        body.tilKommando(
+                            behandlingId,
+                            correlationId,
+                            saksbehandler,
+                        ),
+                    ).fold(
+                        {
+                            when (it) {
+                                is KanIkkeOppdatereTilleggstekstBrev.HarIkkeTilgang -> call.respond403Forbidden(
+                                    ikkeTilgang("${it.kreverEnAvRollene} for å oppdatere tilleggstekst for brev"),
+                                )
+
+                                is KanIkkeOppdatereTilleggstekstBrev.BehandlingErSendtTilBeslutterEllerVedtatt -> call.respond400BadRequest(
+                                    behandlingKanIkkeVæreSendtTilBeslutterEllerVedtatt(),
+                                )
+                            }
+                        },
+                        {
+                            auditService.logMedBehandlingId(
+                                behandlingId = behandlingId,
+                                navIdent = saksbehandler.navIdent,
+                                action = AuditLogEvent.Action.ACCESS,
+                                contextMessage = "Oppdaterer tilleggstekst i brev",
+                                correlationId = correlationId,
+                            )
+
+                            call.respond(status = HttpStatusCode.OK, it.toDTO())
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    post("$BEHANDLING_PATH/{behandlingId}/vurderingsperiode") {
+        logger.debug("Mottatt post-request på '$BEHANDLING_PATH/{behandlingId}/vurderingsperiode' - oppdaterer vurderingsperiode")
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withBehandlingId { behandlingId ->
+                val correlationId = call.correlationId()
+                call.withBody<OppdaterVurderingsPeriodeBody> { body ->
+                    behandlingService.oppdaterVurderingsPeriodeForBehandling(
+                        body.tilKommando(
+                            behandlingId,
+                            correlationId,
+                            saksbehandler,
+                        ),
+                    ).fold(
+                        {
+                            when (it) {
+                                is KanIkkeOppdatereVurderingsperiode.HarIkkeTilgang -> call.respond403Forbidden(
+                                    ikkeTilgang("${it.kreverEnAvRollene} for å oppdatere vurderingsperiode"),
+                                )
+
+                                is KanIkkeOppdatereVurderingsperiode.BehandlingErSendtTilBeslutterEllerVedtatt -> call.respond400BadRequest(
+                                    behandlingKanIkkeVæreSendtTilBeslutterEllerVedtatt(),
+                                )
+
+                                is KanIkkeOppdatereVurderingsperiode.KanKunKrympe -> call.respond400BadRequest(
+                                    nyPeriodeMåVæreInnenforVurderingsperiode("Ny periode må være innenfor opprinnelig vurderingsperiode ${it.opprinnligVurderingsperiode.tilNorskFormat()}"),
+                                )
+                            }
+                        },
+                        {
+                            auditService.logMedBehandlingId(
+                                behandlingId = behandlingId,
+                                navIdent = saksbehandler.navIdent,
+                                action = AuditLogEvent.Action.ACCESS,
+                                contextMessage = "Oppdaterer vurderingsperioden",
+                                correlationId = correlationId,
+                            )
+
+                            call.respond(status = HttpStatusCode.OK, it.toDTO())
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/Subsumsjon.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/Subsumsjon.kt
@@ -1,0 +1,13 @@
+package no.nav.tiltakspenger.vedtak.routes.behandling
+
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
+
+enum class SubsumsjonDTO {
+    TILTAKSDELTAGELSE,
+}
+
+internal fun TilleggstekstBrev.Subsumsjon.toDTO(): SubsumsjonDTO {
+    return when (this) {
+        TilleggstekstBrev.Subsumsjon.TILTAKSDELTAGELSE -> SubsumsjonDTO.TILTAKSDELTAGELSE
+    }
+}

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/TilleggstekstBrevDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/TilleggstekstBrevDTO.kt
@@ -1,0 +1,14 @@
+package no.nav.tiltakspenger.vedtak.routes.behandling
+
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
+
+data class TilleggstekstBrevDTO(
+    val subsumsjon: SubsumsjonDTO,
+    val tekst: String,
+)
+
+fun TilleggstekstBrev.toDTO(): TilleggstekstBrevDTO =
+    TilleggstekstBrevDTO(
+        subsumsjon = subsumsjon.toDTO(),
+        tekst = tekst,
+    )

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/exceptionhandling/Standardfeil.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/exceptionhandling/Standardfeil.kt
@@ -32,6 +32,16 @@ object Standardfeil {
         "må_være_beslutter_eller_saksbehandler",
     )
 
+    fun nyPeriodeMåVæreInnenforVurderingsperiode(melding: String = "Ny periode må være innenfor opprinnelig vurderingsperiode"): ErrorJson = ErrorJson(
+        melding,
+        "ny_periode_må_være_innenfor_vurderingsperiode",
+    )
+
+    fun behandlingKanIkkeVæreSendtTilBeslutterEllerVedtatt(): ErrorJson = ErrorJson(
+        "Behandlingen kan ikke være sendt til beslutter eller vedtatt.",
+        "behandling_kan_ikke_være_til_beslutning_eller_vedtatt",
+    )
+
     fun saksopplysningsperiodeMåVæreLik(): ErrorJson = ErrorJson(
         "Perioden til saksopplysningen er forskjellig fra vurderingsperioden",
         "saksopplysningsperiode_må_være_lik",

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandlingsstatus.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandlingsstatus.kt
@@ -19,4 +19,10 @@ enum class Behandlingsstatus {
 
     /** En avsluttet, besluttet behandling. Brukes litt om hverandre med IVERKSATT. En alternativ avsluttet status vil være avbrutt og vil komme på et senere tidspunkt. */
     VEDTATT,
+
+    ;
+
+    fun erUnderBeslutningEllerKonkludert(): Boolean {
+        return listOf(UNDER_BESLUTNING, VEDTATT).any { it == this }
+    }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/KanIkkeOppdatereTilleggstekstBrev.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/KanIkkeOppdatereTilleggstekstBrev.kt
@@ -1,0 +1,15 @@
+package no.nav.tiltakspenger.saksbehandling.domene.behandling
+
+import no.nav.tiltakspenger.libs.common.Saksbehandlerrolle
+
+sealed interface KanIkkeOppdatereTilleggstekstBrev {
+
+    data class HarIkkeTilgang(
+        val kreverEnAvRollene: Set<Saksbehandlerrolle>,
+        val harRollene: Set<Saksbehandlerrolle>,
+    ) : KanIkkeOppdatereTilleggstekstBrev
+
+    data class BehandlingErSendtTilBeslutterEllerVedtatt(
+        val status: Behandlingsstatus,
+    ) : KanIkkeOppdatereTilleggstekstBrev
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/KanIkkeOppdatereVurderingsperiode.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/KanIkkeOppdatereVurderingsperiode.kt
@@ -1,0 +1,20 @@
+package no.nav.tiltakspenger.saksbehandling.domene.behandling
+
+import no.nav.tiltakspenger.libs.common.Saksbehandlerrolle
+import no.nav.tiltakspenger.libs.periodisering.Periode
+
+sealed interface KanIkkeOppdatereVurderingsperiode {
+
+    data class HarIkkeTilgang(
+        val kreverEnAvRollene: Set<Saksbehandlerrolle>,
+        val harRollene: Set<Saksbehandlerrolle>,
+    ) : KanIkkeOppdatereVurderingsperiode
+
+    data class KanKunKrympe(
+        val opprinnligVurderingsperiode: Periode,
+    ) : KanIkkeOppdatereVurderingsperiode
+
+    data class BehandlingErSendtTilBeslutterEllerVedtatt(
+        val status: Behandlingsstatus,
+    ) : KanIkkeOppdatereVurderingsperiode
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/OppdaterTilleggstekstBrevKommando.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/OppdaterTilleggstekstBrevKommando.kt
@@ -1,0 +1,12 @@
+package no.nav.tiltakspenger.saksbehandling.domene.behandling
+
+import no.nav.tiltakspenger.libs.common.BehandlingId
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+
+data class OppdaterTilleggstekstBrevKommando(
+    val behandlingId: BehandlingId,
+    val correlationId: CorrelationId,
+    val saksbehandler: Saksbehandler,
+    val subsumsjon: TilleggstekstBrev.Subsumsjon,
+)

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/OppdaterVurderingsperiodeKommando.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/OppdaterVurderingsperiodeKommando.kt
@@ -1,0 +1,13 @@
+package no.nav.tiltakspenger.saksbehandling.domene.behandling
+
+import no.nav.tiltakspenger.libs.common.BehandlingId
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.periodisering.Periode
+
+data class OppdaterVurderingsperiodeKommando(
+    val behandlingId: BehandlingId,
+    val periode: Periode,
+    val correlationId: CorrelationId,
+    val saksbehandler: Saksbehandler,
+)

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/TilleggstekstBrev.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/TilleggstekstBrev.kt
@@ -1,0 +1,35 @@
+package no.nav.tiltakspenger.saksbehandling.domene.behandling
+
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import no.nav.tiltakspenger.libs.periodisering.norskDatoMedPunktumFormatter
+
+data class TilleggstekstBrev(
+    val subsumsjon: Subsumsjon,
+    val tekst: String,
+) {
+    enum class Subsumsjon {
+        TILTAKSDELTAGELSE,
+    }
+
+    companion object {
+        fun hentStandardTekstForBegrunnelse(
+            subsumsjon: Subsumsjon,
+            søknadsperiode: Periode,
+            vurderingsperiode: Periode,
+        ): String {
+            when (subsumsjon) {
+                Subsumsjon.TILTAKSDELTAGELSE -> return tiltaksdeltagelse(søknadsperiode, vurderingsperiode)
+            }
+        }
+
+        fun tiltaksdeltagelse(søknadsperiode: Periode, vedtaksperiode: Periode): String {
+            val vedtakFraOgMed = vedtaksperiode.fraOgMed.format(norskDatoMedPunktumFormatter)
+            val vedtakTilOgMed = vedtaksperiode.tilOgMed.format(norskDatoMedPunktumFormatter)
+
+            return """
+            Du har søkt tiltakspenger ${søknadsperiode.tilNorskFormat()}. Din første dag på tiltak er $vedtakFraOgMed.
+            Du har derfor rett til tiltakspenger fra og med $vedtakFraOgMed til og med $vedtakTilOgMed.
+            """.trimIndent()
+        }
+    }
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/vilkår/livsopphold/LivsoppholdVilkår.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/vilkår/livsopphold/LivsoppholdVilkår.kt
@@ -60,7 +60,7 @@ data class LivsoppholdVilkår private constructor(
             vurderingsperiode = nyPeriode,
             søknadssaksopplysning = nySøknadSaksopplysning,
             saksbehandlerSaksopplysning = nySaksbehandlerSaksopplysning,
-            avklartSaksopplysning = nySaksbehandlerSaksopplysning ?: nySøknadSaksopplysning,
+            avklartSaksopplysning = nySaksbehandlerSaksopplysning,
         )
     }
 

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/behandling/BehandlingService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/behandling/BehandlingService.kt
@@ -9,9 +9,13 @@ import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandling
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeHenteBehandling
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeIverksetteBehandling
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeOppdatereTilleggstekstBrev
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeOppdatereVurderingsperiode
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeSendeTilBeslutter
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeTaBehandling
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.KanIkkeUnderkjenne
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterTilleggstekstBrevKommando
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterVurderingsperiodeKommando
 
 interface BehandlingService {
     /**
@@ -48,6 +52,14 @@ interface BehandlingService {
         correlationId: CorrelationId,
         sessionContext: SessionContext? = null,
     ): Either<KanIkkeHenteBehandling, Behandling>
+
+    suspend fun oppdaterVurderingsPeriodeForBehandling(
+        kommando: OppdaterVurderingsperiodeKommando,
+    ): Either<KanIkkeOppdatereVurderingsperiode, Behandling>
+
+    suspend fun oppdaterTilleggstekstBrevPåBehandling(
+        kommando: OppdaterTilleggstekstBrevKommando,
+    ): Either<KanIkkeOppdatereTilleggstekstBrev, Behandling>
 
     suspend fun sendTilBeslutter(
         behandlingId: BehandlingId,

--- a/domene/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/BehandlingServiceTest.kt
+++ b/domene/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/BehandlingServiceTest.kt
@@ -4,11 +4,25 @@ import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import kotlinx.coroutines.test.runTest
 import no.nav.tiltakspenger.common.TestApplicationContext
+import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import no.nav.tiltakspenger.objectmothers.ObjectMother
 import no.nav.tiltakspenger.objectmothers.ObjectMother.beslutter
+import no.nav.tiltakspenger.objectmothers.ObjectMother.saksbehandler
 import no.nav.tiltakspenger.objectmothers.ObjectMother.saksbehandlerUtenTilgang
+import no.nav.tiltakspenger.objectmothers.førstegangsbehandlingIverksatt
 import no.nav.tiltakspenger.objectmothers.førstegangsbehandlingTilBeslutter
+import no.nav.tiltakspenger.objectmothers.førstegangsbehandlingUnderBeslutning
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterTilleggstekstBrevKommando
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.OppdaterVurderingsperiodeKommando
+import no.nav.tiltakspenger.saksbehandling.domene.behandling.TilleggstekstBrev
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal class BehandlingServiceTest {
     @Test
@@ -40,11 +54,217 @@ internal class BehandlingServiceTest {
             val sak = this.førstegangsbehandlingTilBeslutter()
             val behandlingId = sak.førstegangsbehandling.id
             val beslutter = beslutter()
-            this.behandlingContext.behandlingService.taBehandling(behandlingId, beslutter, correlationId = CorrelationId.generate())
+            this.behandlingContext.behandlingService.taBehandling(
+                behandlingId,
+                beslutter,
+                correlationId = CorrelationId.generate(),
+            )
 
-            this.behandlingContext.behandlingService.sendTilbakeTilSaksbehandler(behandlingId, saksbehandlerUtenTilgang(), "begrunnelse", correlationId = CorrelationId.generate()).shouldBeLeft()
+            this.behandlingContext.behandlingService.sendTilbakeTilSaksbehandler(
+                behandlingId,
+                saksbehandlerUtenTilgang(),
+                "begrunnelse",
+                correlationId = CorrelationId.generate(),
+            ).shouldBeLeft()
 
-            this.behandlingContext.behandlingService.sendTilbakeTilSaksbehandler(behandlingId, beslutter, "begrunnelse", correlationId = CorrelationId.generate()).shouldBeRight()
+            this.behandlingContext.behandlingService.sendTilbakeTilSaksbehandler(
+                behandlingId,
+                beslutter,
+                "begrunnelse",
+                correlationId = CorrelationId.generate(),
+            ).shouldBeRight()
+        }
+    }
+
+    @Nested
+    inner class `Oppdatering av vurderingsperiode` {
+        private fun lagKommando(
+            behandlingId: BehandlingId,
+            saksbehandler: Saksbehandler = saksbehandler(),
+            periode: Periode = ObjectMother.vurderingsperiode(),
+        ): OppdaterVurderingsperiodeKommando =
+            OppdaterVurderingsperiodeKommando(
+                behandlingId = behandlingId,
+                correlationId = CorrelationId.generate(),
+                saksbehandler = saksbehandler,
+                periode = periode,
+            )
+
+        @Test
+        fun `krever saksbehandler rolle`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingTilBeslutter()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterVurderingsPeriodeForBehandling(lagKommando(behandlingId))
+                    .shouldBeRight()
+
+                assertThrows<IllegalArgumentException> {
+                    behandlingService
+                        .oppdaterVurderingsPeriodeForBehandling(
+                            lagKommando(
+                                behandlingId = behandlingId,
+                                saksbehandler = saksbehandlerUtenTilgang(),
+                            ),
+                        )
+                        .shouldBeLeft()
+                }
+            }
+        }
+
+        @Test
+        fun `kan ikke endres etter at behandling er tildelt beslutter`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingUnderBeslutning()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterVurderingsPeriodeForBehandling(lagKommando(behandlingId))
+                    .shouldBeLeft()
+            }
+        }
+
+        @Test
+        fun `kan ikke endres etter at behandling er vedtatt`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingIverksatt()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterVurderingsPeriodeForBehandling(lagKommando(behandlingId = behandlingId))
+                    .shouldBeLeft()
+            }
+        }
+
+        @Test
+        fun `periode kan ikke utvides`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingTilBeslutter()
+                val behandlingId = sak.førstegangsbehandling.id
+                // fraOgMed utvides
+                behandlingService.oppdaterVurderingsPeriodeForBehandling(
+                    lagKommando(
+                        behandlingId = behandlingId,
+                        saksbehandler = saksbehandler(),
+                        periode = Periode(
+                            sak.førstegangsbehandling.vurderingsperiode.fraOgMed.minusDays(1),
+                            sak.førstegangsbehandling.vurderingsperiode.tilOgMed,
+                        ),
+                    ),
+                ).shouldBeLeft()
+                // tilOgMed utvides
+                behandlingService.oppdaterVurderingsPeriodeForBehandling(
+                    lagKommando(
+                        behandlingId = behandlingId,
+                        saksbehandler = saksbehandler(),
+                        periode = Periode(
+                            sak.førstegangsbehandling.vurderingsperiode.fraOgMed,
+                            sak.førstegangsbehandling.vurderingsperiode.tilOgMed.plusDays(1),
+                        ),
+                    ),
+                ).shouldBeLeft()
+                // Utvidelse begge veier
+                behandlingService.oppdaterVurderingsPeriodeForBehandling(
+                    lagKommando(
+                        behandlingId = behandlingId,
+                        saksbehandler = saksbehandler(),
+                        periode = Periode(
+                            sak.førstegangsbehandling.vurderingsperiode.fraOgMed.minusDays(1),
+                            sak.førstegangsbehandling.vurderingsperiode.tilOgMed.plusDays(1),
+                        ),
+                    ),
+                ).shouldBeLeft()
+            }
+        }
+    }
+
+    @Nested
+    inner class `Oppdatering av tilleggstekst i  brev for behandling` {
+        private fun lagKommando(
+            behandlingId: BehandlingId,
+            saksbehandler: Saksbehandler = saksbehandler(),
+        ): OppdaterTilleggstekstBrevKommando =
+            OppdaterTilleggstekstBrevKommando(
+                behandlingId = behandlingId,
+                correlationId = CorrelationId.generate(),
+                saksbehandler = saksbehandler,
+                subsumsjon = TilleggstekstBrev.Subsumsjon.TILTAKSDELTAGELSE,
+            )
+
+        @Test
+        fun `krever saksbehandler rolle`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingTilBeslutter()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterTilleggstekstBrevPåBehandling(lagKommando(behandlingId))
+                    .shouldBeRight()
+
+                assertThrows<IllegalArgumentException> {
+                    behandlingService
+                        .oppdaterTilleggstekstBrevPåBehandling(
+                            lagKommando(
+                                behandlingId,
+                                saksbehandler = saksbehandlerUtenTilgang(),
+                            ),
+                        )
+                        .shouldBeLeft()
+                }
+            }
+        }
+
+        @Test
+        fun `kan ikke endres etter at behandling er tildelt beslutter`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingUnderBeslutning()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterTilleggstekstBrevPåBehandling(lagKommando(behandlingId))
+                    .shouldBeLeft()
+            }
+        }
+
+        @Test
+        fun `kan ikke endres etter at behandling er vedtatt`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingIverksatt()
+                val behandlingId = sak.førstegangsbehandling.id
+                behandlingService
+                    .oppdaterTilleggstekstBrevPåBehandling(lagKommando(behandlingId))
+                    .shouldBeLeft()
+            }
+        }
+
+        @Test
+        fun `gjør at tilleggstekst til brev blir oppdatert`() = runTest {
+            with(TestApplicationContext()) {
+                val behandlingService = this.behandlingContext.behandlingService
+                val sak = this.førstegangsbehandlingTilBeslutter()
+                val behandlingId = sak.førstegangsbehandling.id
+                val saksbehandler = saksbehandler()
+
+                val behandlingFørOppdatering =
+                    behandlingService.hentBehandling(behandlingId, saksbehandler, CorrelationId.generate())
+                assertNull(
+                    behandlingFørOppdatering.tilleggstekstBrev,
+                    "Forventet ingen begrunnelse før den blir oppdatert",
+                )
+
+                val behandling = behandlingService
+                    .oppdaterTilleggstekstBrevPåBehandling(lagKommando(behandlingId))
+                    .shouldBeRight()
+
+                assertEquals(
+                    TilleggstekstBrev.Subsumsjon.TILTAKSDELTAGELSE,
+                    behandling.tilleggstekstBrev?.subsumsjon,
+                    "Subsumsjon for tilleggstekst til brev",
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
La saksbehandler krympe vedtaksperioden, men krev en begrunnelse

Begrunnelsen ender opp i vedtaksbrevet for å informere bruker om hvorfor vedtaksperioden er kortere enn perioden de søkte på. Dette kan for eksempel komme av at bruker har begynt på arbeidstiltak senere enn perioden det er søkt for. Begrunnelsen er en standardtekst og per nå er det bare lagt opp til at bare endring i tiltaksdeltagelse er årsak til endring av vedtaksperiode. Dette vil endre seg etterhvert som de andre vilkårene blir periodisert.