### PR TITLE
Sorter meldeperioder

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/meldekort/MeldeperiodePostgresRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/meldekort/MeldeperiodePostgresRepo.kt
@@ -158,6 +158,7 @@ internal class MeldeperiodePostgresRepo(
                     from meldeperiode m 
                     join sak s on s.id = m.sak_id 
                     where m.sak_id = :sak_id
+                    order by m.fra_og_med, m.versjon
                     """,
                     "sak_id" to sakId.toString(),
                 ).map { row -> fromRow(row) }.asList,

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/db/TestDataHelperBehandlingEx.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/db/TestDataHelperBehandlingEx.kt
@@ -10,6 +10,7 @@ import no.nav.tiltakspenger.libs.common.SøknadId
 import no.nav.tiltakspenger.libs.common.random
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.meldekort.domene.MeldekortBehandling
+import no.nav.tiltakspenger.meldekort.domene.opprettFørsteMeldeperiode
 import no.nav.tiltakspenger.objectmothers.ObjectMother
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandling
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.StartRevurderingKommando
@@ -232,13 +233,16 @@ internal fun TestDataHelper.persisterRammevedtakMedUtfyltMeldekort(
         søknad = søknad,
         beslutter = beslutter,
     )
-    val utfyltMeldekort =
-        ObjectMother.utfyltMeldekort(
-            sakId = sak.id,
-            rammevedtakId = vedtak.id,
-            fnr = sak.fnr,
-            saksnummer = sak.saksnummer,
-        )
+    val førsteMeldeperiode = sak.opprettFørsteMeldeperiode()
+    val utfyltMeldekort = ObjectMother.utfyltMeldekort(
+        sakId = sak.id,
+        rammevedtakId = vedtak.id,
+        fnr = sak.fnr,
+        saksnummer = sak.saksnummer,
+        antallDagerForMeldeperiode = vedtak.antallDagerPerMeldeperiode,
+        meldeperiode = førsteMeldeperiode,
+        periode = førsteMeldeperiode.periode,
+    )
     meldekortRepo.lagre(utfyltMeldekort)
     meldeperiodeRepo.lagre(utfyltMeldekort.meldeperiode)
     return Pair(sakRepo.hentForSakId(sakId)!!, utfyltMeldekort)

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/repository/meldekort/MeldekortBehandlingRepoImplTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/repository/meldekort/MeldekortBehandlingRepoImplTest.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.vedtak.repository.meldekort
 
 import io.kotest.matchers.shouldBe
 import no.nav.tiltakspenger.felles.Navkontor
+import no.nav.tiltakspenger.felles.april
 import no.nav.tiltakspenger.felles.januar
 import no.nav.tiltakspenger.felles.mars
 import no.nav.tiltakspenger.libs.common.getOrFail
@@ -22,18 +23,21 @@ class MeldekortBehandlingRepoImplTest {
     @Test
     fun `kan lagre og hente`() {
         withMigratedDb { testDataHelper ->
-            val (sak, vedtak) = testDataHelper.persisterIverksattFørstegangsbehandling()
+            val (sak, vedtak) = testDataHelper.persisterIverksattFørstegangsbehandling(
+                deltakelseFom = 2.januar(2023),
+                deltakelseTom = 2.april(2023),
+            )
 
             val førsteMeldeperiode = sak.opprettFørsteMeldeperiode()
-            val meldekort =
-                ObjectMother.utfyltMeldekort(
-                    sakId = sak.id,
-                    rammevedtakId = vedtak.id,
-                    fnr = sak.fnr,
-                    saksnummer = sak.saksnummer,
-                    antallDagerForMeldeperiode = vedtak.antallDagerPerMeldeperiode,
-                    meldeperiode = førsteMeldeperiode,
-                )
+            val meldekort = ObjectMother.utfyltMeldekort(
+                sakId = sak.id,
+                rammevedtakId = vedtak.id,
+                fnr = sak.fnr,
+                saksnummer = sak.saksnummer,
+                antallDagerForMeldeperiode = vedtak.antallDagerPerMeldeperiode,
+                meldeperiode = førsteMeldeperiode,
+                periode = førsteMeldeperiode.periode,
+            )
 
             val meldekortRepo = testDataHelper.meldekortRepo
             val meldeperiodeRepo = testDataHelper.meldeperiodeRepo

--- a/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/repository/utbetaling/UtbetalingsvedtakRepoImplTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/vedtak/repository/utbetaling/UtbetalingsvedtakRepoImplTest.kt
@@ -1,6 +1,8 @@
 package no.nav.tiltakspenger.vedtak.repository.utbetaling
 
 import io.kotest.matchers.shouldBe
+import no.nav.tiltakspenger.felles.april
+import no.nav.tiltakspenger.felles.januar
 import no.nav.tiltakspenger.felles.journalføring.JournalpostId
 import no.nav.tiltakspenger.felles.nå
 import no.nav.tiltakspenger.saksbehandling.ports.SendtUtbetaling
@@ -16,7 +18,10 @@ class UtbetalingsvedtakRepoImplTest {
         val tidspunkt = nå()
         withMigratedDb(runIsolated = true) { testDataHelper ->
 
-            val (sak, meldekort) = testDataHelper.persisterRammevedtakMedUtfyltMeldekort()
+            val (sak, meldekort) = testDataHelper.persisterRammevedtakMedUtfyltMeldekort(
+                deltakelseFom = 2.januar(2023),
+                deltakelseTom = 2.april(2023),
+            )
             val utbetalingsvedtakRepo = testDataHelper.utbetalingsvedtakRepo as UtbetalingsvedtakPostgresRepo
             val utbetalingsvedtak = meldekort.opprettUtbetalingsvedtak(sak.saksnummer, sak.fnr, null)
             utbetalingsvedtakRepo.lagre(utbetalingsvedtak)

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortBehandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortBehandling.kt
@@ -93,6 +93,8 @@ sealed interface MeldekortBehandling {
     ) : MeldekortBehandling {
 
         init {
+            require(meldeperiode.periode == periode)
+            require(beregning.periode == periode)
             when (status) {
                 MeldekortBehandlingStatus.IKKE_BEHANDLET -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status IKKE_UTFYLT")
                 MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
@@ -51,7 +51,7 @@ fun Sak.opprettFørsteMeldeperiode(): Meldeperiode {
 fun Sak.opprettNesteMeldeperiode(): Meldeperiode? {
     require(this.vedtaksliste.isNotEmpty()) { "Vedtaksliste kan ikke være tom" }
 
-    val siste = this.meldeperiodeKjeder.hentSisteMeldeperiod()
+    val siste = this.meldeperiodeKjeder.hentSisteMeldeperiode()
     // TODO: sjekk at det finnes en gyldig neste periode
     val nestePeriode = Periode(siste.periode.fraOgMed.plusDays(14), siste.periode.tilOgMed.plusDays(14))
 

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjede.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjede.kt
@@ -1,14 +1,29 @@
 package no.nav.tiltakspenger.meldekort.domene
 
 import arrow.core.NonEmptyList
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.MeldeperiodeId
 import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
 
 data class MeldeperiodeKjede(
     val meldeperioder: NonEmptyList<Meldeperiode>,
 ) : List<Meldeperiode> by meldeperioder {
+    // Disse fungerer også som validering, hvis du fjerner må du legge de inn som init.
     val sakId: SakId = meldeperioder.map { it.sakId }.distinct().single()
+    val periode: Periode = meldeperioder.map { it.periode }.distinct().single()
+    val saksnummer: Saksnummer = meldeperioder.map { it.saksnummer }.distinct().single()
+    val fnr: Fnr = meldeperioder.map { it.fnr }.distinct().single()
+    val id: MeldeperiodeId = meldeperioder.map { it.id }.distinct().single()
 
-    fun hentSisteMeldeperiode(): Meldeperiode {
-        return this.last()
+    val sisteVersjon: Meldeperiode = last()
+
+    init {
+        meldeperioder.zipWithNext { a, b ->
+            require(a.versjon.inc() == b.versjon)
+            require(a.opprettet.isBefore(b.opprettet))
+            require(a.hendelseId != b.hendelseId)
+        }
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjeder.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjeder.kt
@@ -1,10 +1,29 @@
 package no.nav.tiltakspenger.meldekort.domene
 
+import no.nav.tiltakspenger.felles.singleOrNullOrThrow
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
+
 data class MeldeperiodeKjeder(val meldeperiodeKjeder: List<MeldeperiodeKjede>) : List<MeldeperiodeKjede> by meldeperiodeKjeder {
-    fun hentSisteMeldeperiod(): Meldeperiode {
-        return this.last().hentSisteMeldeperiode()
+    fun hentSisteMeldeperiode(): Meldeperiode {
+        return this.last().sisteVersjon
     }
 
     /** Siste versjon av meldeperiodene */
     val meldeperioder: List<Meldeperiode> get() = this.map { it.last() }
+
+    val sakId: SakId? = meldeperiodeKjeder.map { it.sakId }.distinct().singleOrNullOrThrow()
+    val saksnummer: Saksnummer? = meldeperiodeKjeder.map { it.saksnummer }.distinct().singleOrNullOrThrow()
+    val fnr: Fnr? = meldeperiodeKjeder.map { it.fnr }.distinct().singleOrNullOrThrow()
+
+    init {
+        require(
+            meldeperiodeKjeder.zipWithNext { a, b ->
+                a.periode.tilOgMed.plusDays(1) == b.periode.fraOgMed
+            }.all {
+                it
+            },
+        )
+    }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/IverksettMeldekortService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/IverksettMeldekortService.kt
@@ -53,7 +53,11 @@ class IverksettMeldekortService(
             "Meldekort $meldekortId er allerede iverksatt"
         }
 
+        // TODO John og Anders: Vi må støtte at dette er siste meldeperiode.
         val nesteMeldeperiode = sak.opprettNesteMeldeperiode() ?: throw IllegalArgumentException("Kunne ikke opprette ny meldeperiode for sak $sakId")
+        require(meldekort.periode.tilOgMed.plusDays(1) == nesteMeldeperiode.periode.fraOgMed) {
+            "Forventet at neste meldekort starter dagen etter nåværende meldekort. saksnummer: ${sak.saksnummer}, sakId: $sakId, meldekortId: $meldekortId, meldeperiodeId: ${meldekort.meldeperiode.id}"
+        }
 
         return meldekort.iverksettMeldekort(kommando.beslutter).onRight { iverksattMeldekort ->
             val nesteMeldekort = iverksattMeldekort.opprettNesteMeldekortBehandling(sak.vedtaksliste.utfallsperioder, nesteMeldeperiode)

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/MeldekortMother.kt
@@ -92,12 +92,24 @@ interface MeldekortMother {
         saksnummer: Saksnummer = Saksnummer.genererSaknummer(løpenr = "1001"),
         fnr: Fnr = Fnr.random(),
         rammevedtakId: VedtakId = VedtakId.random(),
+        periode: Periode,
+        meldeperiodeId: MeldeperiodeId = MeldeperiodeId.fraPeriode(periode),
+        opprettet: LocalDateTime = nå(),
+        meldeperiode: Meldeperiode = meldeperiode(
+            periode = periode,
+            id = meldeperiodeId,
+            sakId = sakId,
+            saksnummer = saksnummer,
+            fnr = fnr,
+            opprettet = opprettet,
+        ),
         meldekortperiodeBeregning: MeldeperiodeBeregning.UtfyltMeldeperiode =
             utfyltMeldekortperiode(
                 meldekortId = id,
                 sakId = sakId,
+                startDato = meldeperiode.periode.fraOgMed,
             ),
-        meldeperiodeId: MeldeperiodeId = MeldeperiodeId.fraPeriode(meldekortperiodeBeregning.periode),
+
         saksbehandler: String = "saksbehandler",
         beslutter: String = "beslutter",
         forrigeMeldekortId: MeldekortId? = null,
@@ -106,16 +118,8 @@ interface MeldekortMother {
         iverksattTidspunkt: LocalDateTime? = nå(),
         navkontor: Navkontor = ObjectMother.navkontor(),
         antallDagerForMeldeperiode: Int = 10,
-        opprettet: LocalDateTime = nå(),
+
         sendtTilBeslutning: LocalDateTime = nå(),
-        meldeperiode: Meldeperiode = meldeperiode(
-            periode = meldekortperiodeBeregning.periode,
-            id = meldeperiodeId,
-            sakId = sakId,
-            saksnummer = saksnummer,
-            fnr = fnr,
-            opprettet = opprettet,
-        ),
 
     ): MeldekortBehandling.UtfyltMeldekort {
         return MeldekortBehandling.UtfyltMeldekort(

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/UtbetalingsvedtakMother.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/UtbetalingsvedtakMother.kt
@@ -1,11 +1,13 @@
 package no.nav.tiltakspenger.objectmothers
 
+import no.nav.tiltakspenger.felles.januar
 import no.nav.tiltakspenger.felles.journalføring.JournalpostId
 import no.nav.tiltakspenger.felles.nå
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.VedtakId
 import no.nav.tiltakspenger.libs.common.random
+import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.meldekort.domene.MeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
 import no.nav.tiltakspenger.utbetaling.domene.Utbetalingsvedtak
@@ -20,10 +22,12 @@ interface UtbetalingsvedtakMother {
         saksnummer: Saksnummer = Saksnummer.genererSaknummer(LocalDate.now(), "1001"),
         fnr: Fnr = Fnr.random(),
         rammevedtakId: VedtakId = VedtakId.random(),
+        periode: Periode = Periode(2.januar(2023), 15.januar(2023)),
         meldekort: MeldekortBehandling.UtfyltMeldekort = ObjectMother.utfyltMeldekort(
             sakId = sakId,
             rammevedtakId = rammevedtakId,
             fnr = fnr,
+            periode = periode,
         ),
         forrigeUtbetalingsvedtakId: VedtakId? = null,
         sendtTilUtbetaling: LocalDateTime? = null,


### PR DESCRIPTION
Vi har en bug i produksjon der beslutter ikke får iverksatt meldekort fordi meldeperiodene ikke hentes i sortert rekkefølge.