### PR TITLE
Synkroniser stansvedtak med meldeperiode og meldekort

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/meldekort/dto/MeldeperiodeKjedeDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/meldekort/dto/MeldeperiodeKjedeDTO.kt
@@ -14,7 +14,7 @@ data class MeldeperiodeKjedeDTO(
 )
 
 fun Sak.toMeldeperiodeKjedeDTO(meldeperiodeKjedeId: MeldeperiodeKjedeId): MeldeperiodeKjedeDTO? {
-    val meldeperiodeKjede = this.meldeperiodeKjeder.find { it.id == meldeperiodeKjedeId } ?: return null
+    val meldeperiodeKjede = this.meldeperiodeKjeder.find { it.kjedeId == meldeperiodeKjedeId } ?: return null
 
     return MeldeperiodeKjedeDTO(
         kjedeId = meldeperiodeKjedeId.toString(),

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortBehandlinger.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldekortBehandlinger.kt
@@ -39,6 +39,7 @@ data class MeldekortBehandlinger(
         require(meldekortUnderBehandling.id == kommando.meldekortId) {
             "MeldekortId i kommando (${kommando.meldekortId}) samsvarer ikke med siste meldekortperiode (${meldekortUnderBehandling.id})"
         }
+
         val meldekortdager = kommando.beregn(eksisterendeMeldekortBehandlinger = this)
         val utfyltMeldeperiode = meldekortUnderBehandling.beregning.tilUtfyltMeldeperiode(meldekortdager).getOrElse {
             return it.left()
@@ -67,6 +68,24 @@ data class MeldekortBehandlinger(
         return verdi.find { it.meldeperiodeKjedeId == meldeperiodeKjedeId }
     }
 
+    /**
+     * Løper igjennom alle ikke-avsluttede meldekortbehandlinger (også de som er sendt til beslutter), setter tilstanden til under behandling, oppdaterer meldeperioden og resetter utfyllinga.
+     */
+    fun oppdaterMedNyeKjeder(oppdaterteKjeder: MeldeperiodeKjeder): Pair<MeldekortBehandlinger, List<MeldekortBehandling>> {
+        return verdi.filter { it.erÅpen() }
+            .fold(Pair(this, emptyList())) { acc, meldekortBehandling ->
+                val meldeperiode = oppdaterteKjeder.hentSisteMeldeperiodeForKjedeId(
+                    kjedeId = meldekortBehandling.meldeperiode.meldeperiodeKjedeId,
+                )
+                meldekortBehandling.oppdaterMeldeperiode(meldeperiode)?.let {
+                    Pair(
+                        acc.first.oppdaterMeldekortbehandling(it),
+                        acc.second + it,
+                    )
+                } ?: acc
+            }
+    }
+
     val periode: Periode by lazy { Periode(verdi.first().fraOgMed, verdi.last().tilOgMed) }
 
     val behandledeMeldekort: List<MeldekortBehandlet> by lazy { verdi.filterIsInstance<MeldekortBehandlet>() }
@@ -85,12 +104,28 @@ data class MeldekortBehandlinger(
     /** Vil kun returnere hele meldekortperioder som er utfylt. Dersom siste meldekortperiode er delvis utfylt, vil ikke disse komme med. */
     val utfylteDager: List<MeldeperiodeBeregningDag.Utfylt> by lazy { behandledeMeldekort.flatMap { it.beregning.dager } }
 
-    /** Så lenge saken er aktiv, vil det siste meldekortet være i tilstanden under behandling. Vil også være null fram til første innvilgelse. */
+    /** Under behandling er ikke-avsluttede meldekortbehandlinger som ikke er til beslutning. */
     val meldekortUnderBehandling: MeldekortUnderBehandling? by lazy {
         verdi.filterIsInstance<MeldekortUnderBehandling>().singleOrNullOrThrow()
     }
 
     val sakId: SakId by lazy { verdi.first().sakId }
+
+    /**
+     * Erstatt eksisterende meldekortbehandling med ny meldekortbehandling.
+     */
+    private fun oppdaterMeldekortbehandling(meldekortBehandling: MeldekortBehandling): MeldekortBehandlinger {
+        return MeldekortBehandlinger(
+            tiltakstype = tiltakstype,
+            verdi = verdi.map {
+                if (it.id == meldekortBehandling.id) {
+                    meldekortBehandling
+                } else {
+                    it
+                }
+            },
+        )
+    }
 
     init {
         verdi.zipWithNext { a, b ->

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/Meldeperiode.kt
@@ -39,7 +39,7 @@ data class Meldeperiode(
         return periode.fraOgMed <= nå().toLocalDate()
     }
 
-//    fun settIkkeRettTilTiltakspenger(periode: Periode, tidspunkt: LocalDateTime): Meldeperiode
+    val ingenDagerGirRett = girRett.values.none { it }
 }
 
 fun Sak.opprettFørsteMeldeperiode(): Meldeperiode {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjede.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/MeldeperiodeKjede.kt
@@ -2,9 +2,11 @@ package no.nav.tiltakspenger.meldekort.domene
 
 import arrow.core.NonEmptyList
 import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.HendelseId
 import no.nav.tiltakspenger.libs.common.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.nonDistinctBy
+import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
 
@@ -17,12 +19,14 @@ data class MeldeperiodeKjede(
     val periode: Periode = meldeperioder.map { it.periode }.distinct().single()
     val saksnummer: Saksnummer = meldeperioder.map { it.saksnummer }.distinct().single()
     val fnr: Fnr = meldeperioder.map { it.fnr }.distinct().single()
-    val id: MeldeperiodeKjedeId = meldeperioder.map { it.meldeperiodeKjedeId }.distinct().single()
+    val kjedeId: MeldeperiodeKjedeId = meldeperioder.map { it.meldeperiodeKjedeId }.distinct().single()
+
+    val siste = meldeperioder.last()
 
     init {
         meldeperioder.nonDistinctBy { it.id }.also {
             require(it.isEmpty()) {
-                "Meldeperiodekjeden $id har duplikate meldeperioder - $it"
+                "Meldeperiodekjeden $kjedeId har duplikate meldeperioder - $it"
             }
         }
 
@@ -34,7 +38,41 @@ data class MeldeperiodeKjede(
         }
     }
 
+    /**
+     * Legger til en ny meldeperiode i kjeden dersom den overlapper med stansperioden.
+     * Setter [Meldeperiode.antallDagerForPeriode] til 0 dersom ingen av dagene i meldeperioden gir rett.
+     * Oppdaterer [Meldeperiode.girRett] basert på [stansperiode]
+     * Inkrementerer [Meldeperiode.versjon] med 1.
+     */
+    fun oppdaterMedNyStansperiode(stansperiode: Periode): Pair<MeldeperiodeKjede, Meldeperiode?> {
+        val erFullstendigStans = stansperiode.inneholderHele(this.periode)
+        return if (stansperiode.overlapperMed(this.periode)) {
+            val oppdatertMeldeperiode = Meldeperiode(
+                meldeperiodeKjedeId = kjedeId,
+                id = HendelseId.random(),
+                versjon = siste.versjon.inc(),
+                periode = this.periode,
+                opprettet = nå(),
+                sakId = sakId,
+                saksnummer = saksnummer,
+                fnr = fnr,
+                // Kommentar jah: Småplukk. Dersom dager som gir rett < siste.antallDagerForPeriode, bør vi krympet antallDagerForPeriode?
+                // Meldeperiode burde isåfall ha noe i init-en sin dersom det er en slik avhengighet mellom typene.
+                antallDagerForPeriode = if (erFullstendigStans) 0 else siste.antallDagerForPeriode,
+                girRett = siste.girRett.mapValues { (dag, girRett) -> if (stansperiode.inneholder(dag)) false else girRett },
+                sendtTilMeldekortApi = null,
+            )
+            Pair(this.leggTilMeldeperiode(oppdatertMeldeperiode), oppdatertMeldeperiode)
+        } else {
+            Pair(this, null)
+        }
+    }
+
     fun hentSisteMeldeperiode(): Meldeperiode {
         return meldeperioder.last()
+    }
+
+    fun leggTilMeldeperiode(meldeperiode: Meldeperiode): MeldeperiodeKjede {
+        return MeldeperiodeKjede(meldeperioder + meldeperiode)
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/SendMeldekortTilBeslutterKommando.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/domene/SendMeldekortTilBeslutterKommando.kt
@@ -68,5 +68,7 @@ class SendMeldekortTilBeslutterKommando(
                 SPERRET, IKKE_DELTATT -> false
             }
         }
+
+        fun girRett() = SPERRET != this
     }
 }

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/IverksettMeldekortService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/meldekort/service/IverksettMeldekortService.kt
@@ -25,6 +25,7 @@ import no.nav.tiltakspenger.saksbehandling.service.sak.SakService
 import no.nav.tiltakspenger.utbetaling.domene.opprettUtbetalingsvedtak
 import no.nav.tiltakspenger.utbetaling.domene.tilStatistikk
 import no.nav.tiltakspenger.utbetaling.ports.UtbetalingsvedtakRepo
+import java.lang.IllegalStateException
 
 class IverksettMeldekortService(
     val sakService: SakService,
@@ -55,6 +56,10 @@ class IverksettMeldekortService(
         meldekortBehandling as MeldekortBehandling.MeldekortBehandlet
         require(meldekortBehandling.beslutter == null && meldekortBehandling.status == MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING) {
             "Meldekort $meldekortId er allerede iverksatt"
+        }
+        val meldeperiode = meldekortBehandling.meldeperiode
+        if (!sak.erSisteVersjonAvMeldeperiode(meldeperiode)) {
+            throw IllegalStateException("Kan ikke iverksette meldekortbehandling hvor meldeperioden (${meldeperiode.versjon}) ikke er siste versjon av meldeperioden i saken. sakId: $sakId, meldekortId: $meldekortId")
         }
 
         val nesteMeldeperiode: Meldeperiode? = sak.opprettNesteMeldeperiode()?.let {

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/sak/Sak.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/sak/Sak.kt
@@ -88,6 +88,10 @@ data class Sak(
         min(it, vedtaksperiode!!.tilOgMed)
     } ?: vedtaksperiode?.fraOgMed
 
+    fun erSisteVersjonAvMeldeperiode(meldeperiode: Meldeperiode): Boolean {
+        return meldeperiodeKjeder.erSisteVersjonAvMeldeperiode(meldeperiode)
+    }
+
     companion object {
         fun lagSak(
             sakId: SakId = SakId.random(),

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/sak/SakService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/sak/SakService.kt
@@ -34,6 +34,9 @@ interface SakService {
         correlationId: CorrelationId,
     ): Either<KunneIkkeHenteSakForFnr, Sak>
 
+    /**
+     * Sjekker tilgang til person og at saksbehandler har SAKSBEHANDLER-rollen.
+     */
     suspend fun hentForSakId(
         sakId: SakId,
         saksbehandler: Saksbehandler,

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/sak/SakServiceImpl.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/sak/SakServiceImpl.kt
@@ -133,7 +133,7 @@ class SakServiceImpl(
         }
         val sak = sakRepo.hentForSaksnummer(saksnummer)
             ?: throw IkkeFunnetException("Fant ikke sak med saksnummer $saksnummer")
-        sjekkTilgangTilSak(sak.id, saksbehandler, correlationId)
+        sjekkTilgangTilPerson(sak.id, saksbehandler, correlationId)
 
         return sak.right()
     }
@@ -155,7 +155,7 @@ class SakServiceImpl(
         if (saker.size > 1) throw IllegalStateException("Vi støtter ikke flere saker per søker i piloten.")
 
         val sak = saker.single()
-        sjekkTilgangTilSak(sak.id, saksbehandler, correlationId)
+        sjekkTilgangTilPerson(sak.id, saksbehandler, correlationId)
 
         return sak.right()
     }
@@ -172,7 +172,7 @@ class SakServiceImpl(
                 harRollene = saksbehandler.roller,
             ).left()
         }
-        sjekkTilgangTilSak(sakId, saksbehandler, correlationId)
+        sjekkTilgangTilPerson(sakId, saksbehandler, correlationId)
         return sakRepo.hentForSakId(sakId)!!.right()
     }
 
@@ -230,7 +230,7 @@ class SakServiceImpl(
         return personMedSkjerming.right()
     }
 
-    private suspend fun sjekkTilgangTilSak(sakId: SakId, saksbehandler: Saksbehandler, correlationId: CorrelationId) {
+    private suspend fun sjekkTilgangTilPerson(sakId: SakId, saksbehandler: Saksbehandler, correlationId: CorrelationId) {
         val fnr = personService.hentFnrForSakId(sakId)
         tilgangsstyringService
             .harTilgangTilPerson(


### PR DESCRIPTION
- Lager ny meldeperiode når man iverksetter stans-revurdering.
- Sperrer fra å iverksette meldekortbehandling med utdatert meldeperiode.
- Sperrer fra å sende meldekortbehandling til beslutning med utdatert meldeperiode.
- Dersom det finnes en åpen meldekortbehandling når man iverksetter revurdering, og det genereres en ny meldeperiode som gjør meldeperioden på behandlingen utdatert overskriver vi meldeperioden, fjerner beregningen og setter behandlingen til under behandling