### PR TITLE
Saksopplysninger liste tiltaksdeltagelser

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/kafka/tiltaksdeltakelser/jobb/EndretTiltaksdeltakerJobb.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/kafka/tiltaksdeltakelser/jobb/EndretTiltaksdeltakerJobb.kt
@@ -32,7 +32,8 @@ class EndretTiltaksdeltakerJobb(
             }
             log.info { "Fant behandling ${nyesteIverksatteBehandling.id} for sakId ${it.sakId} og deltakerId ${it.id}" }
 
-            val tiltaksdeltakelseFraBehandling = nyesteIverksatteBehandling.tiltaksdeltakelse
+            val tiltaksdeltakelseFraBehandling = nyesteIverksatteBehandling.getTiltaksdeltagelse(it.id)
+                ?: throw IllegalStateException("Fant ikke deltaker med id ${it.id} på behandling ${nyesteIverksatteBehandling.id}, skal ikke kunne skje")
             if (it.tiltaksdeltakelseErEndret(tiltaksdeltakelseFraBehandling)) {
                 log.info { "Tiltaksdeltakelse ${it.id} er endret, oppretter oppgave" }
                 val oppgaveId = oppgaveGateway.opprettOppgaveUtenDuplikatkontroll(sak.fnr, Oppgavebehov.ENDRET_TILTAKDELTAKER)
@@ -62,9 +63,10 @@ class EndretTiltaksdeltakerJobb(
         }
     }
 
+    // TODO: Når behandlinger kan iverksettes med annet resultat enn at det innvilges tiltakspenger så må vi passe på å filtrere bort disse
     private fun finnNyesteIverksatteBehandlingForDeltakelse(sak: Sak, tiltaksdeltakerId: String): Behandling? {
         val iverksatteBehandlingerForDeltakelse =
-            sak.behandlinger.behandlinger.filter { it.tiltaksid == tiltaksdeltakerId && it.iverksattTidspunkt != null }
+            sak.behandlinger.behandlinger.filter { it.inneholderEksternDeltagelseId(tiltaksdeltakerId) && it.iverksattTidspunkt != null }
         return iverksatteBehandlingerForDeltakelse.maxByOrNull { it.iverksattTidspunkt!! }
     }
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/BehandlingPostgresRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/BehandlingPostgresRepo.kt
@@ -166,6 +166,7 @@ class BehandlingPostgresRepo(
                             "saksopplysningsperiode_fra_og_med" to behandling.saksopplysningsperiode?.fraOgMed,
                             "saksopplysningsperiode_til_og_med" to behandling.saksopplysningsperiode?.tilOgMed,
                             "barnetillegg" to behandling.barnetillegg?.toDbJson(),
+                            "valgte_tiltaksdeltakelser" to behandling.valgteTiltaksdeltakelser?.toDbJson(),
                         ),
                     ).asUpdate,
                 )
@@ -205,6 +206,7 @@ class BehandlingPostgresRepo(
                         "saksopplysningsperiode_fra_og_med" to behandling.saksopplysningsperiode?.fraOgMed,
                         "saksopplysningsperiode_til_og_med" to behandling.saksopplysningsperiode?.tilOgMed,
                         "barnetillegg" to behandling.barnetillegg?.toDbJson(),
+                        "valgte_tiltaksdeltakelser" to behandling.valgteTiltaksdeltakelser?.toDbJson(),
                     ),
                 ).asUpdate,
             )
@@ -251,6 +253,8 @@ class BehandlingPostgresRepo(
             val saksopplysningsperiodeFraOgMed = localDateOrNull("saksopplysningsperiode_fra_og_med")
             val saksopplysningsperiodeTilOgMed = localDateOrNull("saksopplysningsperiode_til_og_med")
             val barnetillegg = stringOrNull("barnetillegg")?.toBarnetillegg()
+            val saksopplysninger = string("saksopplysninger").toSaksopplysninger()
+            val valgteTiltaksdeltakelser = stringOrNull("valgte_tiltaksdeltakelser")?.toValgteTiltaksdeltakelser(saksopplysninger)
 
             return Behandling(
                 id = id,
@@ -259,7 +263,7 @@ class BehandlingPostgresRepo(
                 fnr = fnr,
                 søknad = søknad,
                 virkningsperiode = virkningsperiode,
-                saksopplysninger = string("saksopplysninger").toSaksopplysninger(),
+                saksopplysninger = saksopplysninger,
                 saksbehandler = saksbehandler,
                 sendtTilBeslutning = sendtTilBeslutning,
                 beslutter = beslutter,
@@ -285,6 +289,7 @@ class BehandlingPostgresRepo(
                 },
                 // TODO John + Anders: Må persisteres og hentes opp fra basen!
                 barnetillegg = barnetillegg,
+                valgteTiltaksdeltakelser = valgteTiltaksdeltakelser,
             )
         }
 
@@ -314,7 +319,8 @@ class BehandlingPostgresRepo(
                 saksopplysninger,
                 saksopplysningsperiode_fra_og_med,
                 saksopplysningsperiode_til_og_med,
-                barnetillegg
+                barnetillegg,
+                valgte_tiltaksdeltakelser
             ) values (
                 :id,
                 :sak_id,
@@ -338,7 +344,8 @@ class BehandlingPostgresRepo(
                 to_jsonb(:saksopplysninger::jsonb),
                 :saksopplysningsperiode_fra_og_med,
                 :saksopplysningsperiode_til_og_med,
-                to_jsonb(:barnetillegg::jsonb)
+                to_jsonb(:barnetillegg::jsonb),
+                to_jsonb(:valgte_tiltaksdeltakelser::jsonb)
             )
             """.trimIndent()
 
@@ -366,7 +373,8 @@ class BehandlingPostgresRepo(
                 saksopplysninger = to_jsonb(:saksopplysninger::jsonb),
                 saksopplysningsperiode_fra_og_med = :saksopplysningsperiode_fra_og_med,
                 saksopplysningsperiode_til_og_med = :saksopplysningsperiode_til_og_med,
-                barneTillegg = to_jsonb(:barnetillegg::jsonb)
+                barneTillegg = to_jsonb(:barnetillegg::jsonb),
+                valgte_tiltaksdeltakelser = to_jsonb(:valgte_tiltaksdeltakelser::jsonb)
             where id = :id
               and sist_endret = :sist_endret_old
             """.trimIndent()

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/SaksopplysningerDbJson.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/SaksopplysningerDbJson.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 
 private data class SaksopplysningerDbJson(
     val fødselsdato: String,
-    val tiltaksdeltagelse: TiltaksdeltagelseDbJson,
+    val tiltaksdeltagelse: List<TiltaksdeltagelseDbJson>,
 ) {
     data class TiltaksdeltagelseDbJson(
         val eksternDeltagelseId: String,
@@ -66,7 +66,7 @@ private fun Tiltaksdeltagelse.toDbJson(): TiltaksdeltagelseDbJson {
 fun Saksopplysninger.toDbJson(): String {
     return SaksopplysningerDbJson(
         fødselsdato = fødselsdato.toString(),
-        tiltaksdeltagelse = tiltaksdeltagelse.toDbJson(),
+        tiltaksdeltagelse = tiltaksdeltagelse.map { it.toDbJson() },
     ).let { serialize(it) }
 }
 
@@ -74,6 +74,6 @@ fun String.toSaksopplysninger(): Saksopplysninger {
     val dbJson = deserialize<SaksopplysningerDbJson>(this)
     return Saksopplysninger(
         fødselsdato = LocalDate.parse(dbJson.fødselsdato),
-        tiltaksdeltagelse = dbJson.tiltaksdeltagelse.toDomain(),
+        tiltaksdeltagelse = dbJson.tiltaksdeltagelse.map { it.toDomain() },
     )
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/ValgteTiltaksdeltagelserDbJson.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/ValgteTiltaksdeltagelserDbJson.kt
@@ -15,7 +15,7 @@ private data class ValgteTiltaksdeltakelserDbJson(
 
 private data class TiltaksdeltakelsePeriodeMedVerdi(
     val periode: PeriodeDbJson,
-    val verdi: String,
+    val eksternDeltagelseId: String,
 )
 
 fun String.toValgteTiltaksdeltakelser(saksopplysninger: Saksopplysninger): ValgteTiltaksdeltakelser {
@@ -25,8 +25,8 @@ fun String.toValgteTiltaksdeltakelser(saksopplysninger: Saksopplysninger): Valgt
             valgteTiltaksdeltakelserDbJson.value.map {
                 PeriodeMedVerdi(
                     periode = it.periode.toDomain(),
-                    verdi = saksopplysninger.getTiltaksdeltagelse(it.verdi)
-                        ?: throw IllegalStateException("Fant ikke tiltaksdeltakelse med id ${it.verdi} fra saksopplysninger"),
+                    verdi = saksopplysninger.getTiltaksdeltagelse(it.eksternDeltagelseId)
+                        ?: throw IllegalStateException("Fant ikke tiltaksdeltakelse med id ${it.eksternDeltagelseId} fra saksopplysninger"),
                 )
             },
         ),
@@ -37,7 +37,7 @@ fun ValgteTiltaksdeltakelser.toDbJson(): String = ValgteTiltaksdeltakelserDbJson
     value = this.periodisering.perioderMedVerdi.map {
         TiltaksdeltakelsePeriodeMedVerdi(
             periode = it.periode.toDbJson(),
-            verdi = it.verdi.eksternDeltagelseId,
+            eksternDeltagelseId = it.verdi.eksternDeltagelseId,
         )
     },
 ).let { serialize(it) }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/ValgteTiltaksdeltagelserDbJson.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/repository/behandling/ValgteTiltaksdeltagelserDbJson.kt
@@ -1,0 +1,43 @@
+package no.nav.tiltakspenger.vedtak.repository.behandling
+
+import no.nav.tiltakspenger.libs.json.deserialize
+import no.nav.tiltakspenger.libs.json.serialize
+import no.nav.tiltakspenger.libs.periodisering.PeriodeMedVerdi
+import no.nav.tiltakspenger.libs.periodisering.Periodisering
+import no.nav.tiltakspenger.saksbehandling.domene.saksopplysninger.Saksopplysninger
+import no.nav.tiltakspenger.saksbehandling.domene.tiltak.ValgteTiltaksdeltakelser
+import no.nav.tiltakspenger.vedtak.repository.felles.PeriodeDbJson
+import no.nav.tiltakspenger.vedtak.repository.felles.toDbJson
+
+private data class ValgteTiltaksdeltakelserDbJson(
+    val value: List<TiltaksdeltakelsePeriodeMedVerdi>,
+)
+
+private data class TiltaksdeltakelsePeriodeMedVerdi(
+    val periode: PeriodeDbJson,
+    val verdi: String,
+)
+
+fun String.toValgteTiltaksdeltakelser(saksopplysninger: Saksopplysninger): ValgteTiltaksdeltakelser {
+    val valgteTiltaksdeltakelserDbJson = deserialize<ValgteTiltaksdeltakelserDbJson>(this)
+    return ValgteTiltaksdeltakelser(
+        periodisering = Periodisering(
+            valgteTiltaksdeltakelserDbJson.value.map {
+                PeriodeMedVerdi(
+                    periode = it.periode.toDomain(),
+                    verdi = saksopplysninger.getTiltaksdeltagelse(it.verdi)
+                        ?: throw IllegalStateException("Fant ikke tiltaksdeltakelse med id ${it.verdi} fra saksopplysninger"),
+                )
+            },
+        ),
+    )
+}
+
+fun ValgteTiltaksdeltakelser.toDbJson(): String = ValgteTiltaksdeltakelserDbJson(
+    value = this.periodisering.perioderMedVerdi.map {
+        TiltaksdeltakelsePeriodeMedVerdi(
+            periode = it.periode.toDbJson(),
+            verdi = it.verdi.eksternDeltagelseId,
+        )
+    },
+).let { serialize(it) }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/dto/SaksopplysningerDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/routes/behandling/dto/SaksopplysningerDTO.kt
@@ -10,6 +10,6 @@ data class SaksopplysningerDTO(
 fun Saksopplysninger.toDTO(): SaksopplysningerDTO {
     return SaksopplysningerDTO(
         fødselsdato = this.fødselsdato.toString(),
-        tiltaksdeltagelse = listOf(this.tiltaksdeltagelse.toDTO()),
+        tiltaksdeltagelse = this.tiltaksdeltagelse.map { it.toDTO() },
     )
 }

--- a/app/src/main/resources/db/migration/V46__valgte_tiltaksdeltakelser.sql
+++ b/app/src/main/resources/db/migration/V46__valgte_tiltaksdeltakelser.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behandling ADD COLUMN IF NOT EXISTS valgte_tiltaksdeltakelser jsonb;

--- a/app/src/main/resources/db/migration/V47__migrer_valgte_tiltaksdeltakelser.sql
+++ b/app/src/main/resources/db/migration/V47__migrer_valgte_tiltaksdeltakelser.sql
@@ -16,7 +16,7 @@ UPDATE behandling b
 SET valgte_tiltaksdeltakelser = jsonb_build_object(
   'value', jsonb_build_array(
     jsonb_build_object(
-      'verdi', e.tiltakid,
+      'eksternDeltagelseId', e.tiltakid,
       'periode', jsonb_build_object(
         'fraOgMed', e.virkningsperiode_fra_og_med,
         'tilOgMed', e.virkningsperiode_til_og_med

--- a/app/src/main/resources/db/migration/V47__migrer_valgte_tiltaksdeltakelser.sql
+++ b/app/src/main/resources/db/migration/V47__migrer_valgte_tiltaksdeltakelser.sql
@@ -1,0 +1,28 @@
+WITH extracted_data AS (
+  SELECT
+    id,
+    virkningsperiode_fra_og_med,
+    virkningsperiode_til_og_med,
+    (saksopplysninger->'tiltaksdeltagelse'->'eksternDeltagelseId') AS tiltakid
+  FROM behandling
+  WHERE saksopplysninger IS NOT NULL
+    AND virkningsperiode_fra_og_med IS NOT NULL
+    AND virkningsperiode_til_og_med IS NOT NULL
+    AND (saksopplysninger->>'tiltaksdeltagelse')::jsonb->'eksternDeltagelseId' IS NOT NULL
+    AND valgte_tiltaksdeltakelser IS NULL
+    AND status != 'KLAR_TIL_BEHANDLING'
+)
+UPDATE behandling b
+SET valgte_tiltaksdeltakelser = jsonb_build_object(
+  'value', jsonb_build_array(
+    jsonb_build_object(
+      'verdi', e.tiltakid,
+      'periode', jsonb_build_object(
+        'fraOgMed', e.virkningsperiode_fra_og_med,
+        'tilOgMed', e.virkningsperiode_til_og_med
+      )
+    )
+  )
+)
+FROM extracted_data e
+WHERE b.id = e.id;

--- a/app/src/main/resources/db/migration/V48__migrer_saksopplysninger_tiltaksdeltagelser.sql
+++ b/app/src/main/resources/db/migration/V48__migrer_saksopplysninger_tiltaksdeltagelser.sql
@@ -1,0 +1,30 @@
+WITH extracted_data AS (
+    SELECT
+        id,
+        (saksopplysninger->'fødselsdato') AS fødselsdato,
+        (saksopplysninger->'tiltaksdeltagelse') AS tiltak
+    FROM behandling
+    WHERE saksopplysninger IS NOT NULL
+)
+UPDATE behandling b
+SET saksopplysninger = jsonb_build_object(
+  'fødselsdato', e.fødselsdato,
+  'tiltaksdeltagelse', jsonb_build_array(
+    jsonb_build_object(
+      'id', tiltak->'id',
+      'eksternDeltagelseId', tiltak->'eksternDeltagelseId',
+      'gjennomføringId', tiltak->'gjennomføringId',
+      'typeNavn', tiltak->'typeNavn',
+      'typeKode', tiltak->'typeKode',
+      'deltagelseFraOgMed', tiltak->'deltagelseFraOgMed',
+      'deltagelseTilOgMed', tiltak->'deltagelseTilOgMed',
+      'deltakelseStatus', tiltak->'deltakelseStatus',
+      'deltakelseProsent', tiltak->'deltakelseProsent',
+      'antallDagerPerUke', tiltak->'antallDagerPerUke',
+      'kilde', tiltak->'kilde',
+      'rettPåTiltakspenger', tiltak->'rettPåTiltakspenger'
+    )
+  )
+)
+FROM extracted_data e
+WHERE b.id = e.id;

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandling.kt
@@ -22,6 +22,7 @@ import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandlingstype.REV
 import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
 import no.nav.tiltakspenger.saksbehandling.domene.saksopplysninger.Saksopplysninger
 import no.nav.tiltakspenger.saksbehandling.domene.tiltak.Tiltaksdeltagelse
+import no.nav.tiltakspenger.saksbehandling.domene.tiltak.ValgteTiltaksdeltakelser
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode.RETT_TIL_TILTAKSPENGER
@@ -61,6 +62,7 @@ data class Behandling(
     val begrunnelseVilkårsvurdering: BegrunnelseVilkårsvurdering?,
     val saksopplysningsperiode: Periode?,
     val barnetillegg: Barnetillegg?,
+    val valgteTiltaksdeltakelser: ValgteTiltaksdeltakelser?,
 ) {
     val erUnderBehandling: Boolean = status == UNDER_BEHANDLING
 
@@ -79,8 +81,7 @@ data class Behandling(
     fun inneholderEksternDeltagelseId(eksternDeltagelseId: String): Boolean =
         saksopplysninger.tiltaksdeltagelse.find { it.eksternDeltagelseId == eksternDeltagelseId } != null
 
-    fun getTiltaksdeltagelse(eksternDeltagelseId: String): Tiltaksdeltagelse? =
-        saksopplysninger.tiltaksdeltagelse.find { it.eksternDeltagelseId == eksternDeltagelseId }
+    fun getTiltaksdeltagelse(eksternDeltagelseId: String): Tiltaksdeltagelse? = saksopplysninger.getTiltaksdeltagelse(eksternDeltagelseId)
 
     /**
      * null dersom [virkningsperiode] ikke er satt enda. Typisk i stegene før til beslutning eller ved avslag.
@@ -147,6 +148,7 @@ data class Behandling(
                 oppgaveId = søknad.oppgaveId,
                 saksopplysningsperiode = saksopplysningsperiode,
                 barnetillegg = null,
+                valgteTiltaksdeltakelser = null,
             ).right()
         }
 
@@ -184,6 +186,7 @@ data class Behandling(
                 // Kommentar John: Dersom en revurdering tar utgangspunkt i en søknad, bør denne bestemmes på samme måte som for førstegangsbehandling.
                 saksopplysningsperiode = saksopplysningsperiode,
                 barnetillegg = null,
+                valgteTiltaksdeltakelser = null,
             )
         }
     }
@@ -234,6 +237,7 @@ data class Behandling(
             begrunnelseVilkårsvurdering = kommando.begrunnelseVilkårsvurdering,
             virkningsperiode = kommando.innvilgelsesperiode,
             barnetillegg = kommando.barnetillegg(),
+            valgteTiltaksdeltakelser = ValgteTiltaksdeltakelser.periodiser(tiltaksdeltakelse, kommando.innvilgelsesperiode),
         )
     }
 

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandling.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/behandling/Behandling.kt
@@ -21,6 +21,7 @@ import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandlingstype.FØ
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandlingstype.REVURDERING
 import no.nav.tiltakspenger.saksbehandling.domene.sak.Saksnummer
 import no.nav.tiltakspenger.saksbehandling.domene.saksopplysninger.Saksopplysninger
+import no.nav.tiltakspenger.saksbehandling.domene.tiltak.Tiltaksdeltagelse
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.domene.vilkår.Utfallsperiode.RETT_TIL_TILTAKSPENGER
@@ -68,12 +69,18 @@ data class Behandling(
     /** John og Agnethe har kommet fram til at vi setter denne til 14 dager for meldeperiode i førsteomgang. Hvis det fører til mye feilutbetaling eller lignende må vi la saksbehandler periodisere dette selv, litt på samme måte som barnetillegg. */
     val maksDagerMedTiltakspengerForPeriode: Int = 14
 
-    val tiltaksnavn = saksopplysninger.tiltaksdeltagelse.typeNavn
-    val tiltakstype: TiltakstypeSomGirRett = saksopplysninger.tiltaksdeltagelse.typeKode
-    val tiltaksid: String = saksopplysninger.tiltaksdeltagelse.eksternDeltagelseId
-    val gjennomføringId: String? = saksopplysninger.tiltaksdeltagelse.gjennomføringId
+    // TODO: Når saksbehandler kan velge hvilken deltakelse som gjelder på hvilke dager må vi bruke det som er valgt, ikke bare den første
+    private val tiltaksdeltakelse = saksopplysninger.tiltaksdeltagelse.first()
+    val tiltaksnavn = tiltaksdeltakelse.typeNavn
+    val tiltakstype: TiltakstypeSomGirRett = tiltaksdeltakelse.typeKode
+    val tiltaksid: String = tiltaksdeltakelse.eksternDeltagelseId
+    val gjennomføringId: String? = tiltaksdeltakelse.gjennomføringId
 
-    val tiltaksdeltakelse = saksopplysninger.tiltaksdeltagelse
+    fun inneholderEksternDeltagelseId(eksternDeltagelseId: String): Boolean =
+        saksopplysninger.tiltaksdeltagelse.find { it.eksternDeltagelseId == eksternDeltagelseId } != null
+
+    fun getTiltaksdeltagelse(eksternDeltagelseId: String): Tiltaksdeltagelse? =
+        saksopplysninger.tiltaksdeltagelse.find { it.eksternDeltagelseId == eksternDeltagelseId }
 
     /**
      * null dersom [virkningsperiode] ikke er satt enda. Typisk i stegene før til beslutning eller ved avslag.

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/saksopplysninger/Saksopplysninger.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/saksopplysninger/Saksopplysninger.kt
@@ -4,10 +4,9 @@ import no.nav.tiltakspenger.saksbehandling.domene.tiltak.Tiltaksdeltagelse
 import java.time.LocalDate
 
 /**
- * Et sett med opplysninger som er relevante for saksbehandlingen. En [no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandling] vil på sikt ha en referanse til [Saksopplysninger].
+ * Et sett med opplysninger som er relevante for saksbehandlingen. En [no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandling] vil ha en referanse til [Saksopplysninger].
  */
 data class Saksopplysninger(
     val fødselsdato: LocalDate,
-    /** TODO John + Anders: Vurder på hvilket tidspunkt denne kan gjøres om til en liste. Kan det vente til vi har slettet vilkårssettet? */
-    val tiltaksdeltagelse: Tiltaksdeltagelse,
+    val tiltaksdeltagelse: List<Tiltaksdeltagelse>,
 )

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/saksopplysninger/Saksopplysninger.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/saksopplysninger/Saksopplysninger.kt
@@ -9,4 +9,7 @@ import java.time.LocalDate
 data class Saksopplysninger(
     val fødselsdato: LocalDate,
     val tiltaksdeltagelse: List<Tiltaksdeltagelse>,
-)
+) {
+    fun getTiltaksdeltagelse(eksternDeltagelseId: String): Tiltaksdeltagelse? =
+        tiltaksdeltagelse.find { it.eksternDeltagelseId == eksternDeltagelseId }
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/tiltak/ValgteTiltaksdeltakelser.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/tiltak/ValgteTiltaksdeltakelser.kt
@@ -1,0 +1,27 @@
+package no.nav.tiltakspenger.saksbehandling.domene.tiltak
+
+import no.nav.tiltakspenger.libs.periodisering.Periode
+import no.nav.tiltakspenger.libs.periodisering.PeriodeMedVerdi
+import no.nav.tiltakspenger.libs.periodisering.Periodisering
+
+/**
+ * Saksbehandler skal kunne velge hvilke tiltaksdeltakelser man velger å innvilge tiltakspenger for i gitte perioder,
+ * f.eks. ved overlappende tiltaksdeltakelser
+ */
+data class ValgteTiltaksdeltakelser(
+    val periodisering: Periodisering<Tiltaksdeltagelse>,
+) {
+    companion object {
+        // TODO: Sett inn det saksbehandler faktisk valgte og sjekk at det ikke er huller eller overlapp
+        fun periodiser(
+            tiltaksdeltagelse: Tiltaksdeltagelse,
+            periode: Periode,
+        ): ValgteTiltaksdeltakelser {
+            return ValgteTiltaksdeltakelser(
+                periodisering = Periodisering(
+                    PeriodeMedVerdi(tiltaksdeltagelse, periode),
+                ),
+            )
+        }
+    }
+}

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/vedtak/Vedtaksliste.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/domene/vedtak/Vedtaksliste.kt
@@ -80,8 +80,9 @@ data class Vedtaksliste(
         }
     }
 
+    // TODO: Her må vi bruke periodiseringen fra behandlingen når den er klar
     val tiltaksdeltagelseperioder: Periodisering<Tiltaksdeltagelse> by lazy {
-        saksopplysningerperiode.map { it.tiltaksdeltagelse }
+        saksopplysningerperiode.map { it.tiltaksdeltagelse.first() }
     }
 
     /** Tidslinje for antall barn. Første og siste periode vil være 1 eller flere. Kan inneholde hull med 0 barn. */

--- a/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/behandling/OppdaterSaksopplysningerService.kt
+++ b/domene/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/service/behandling/OppdaterSaksopplysningerService.kt
@@ -61,8 +61,7 @@ class OppdaterSaksopplysningerService(
         val overlappendeTiltak = alleRelevanteTiltak.filter { it.overlapperMedPeriode(saksopplysningsperiode) }
         return Saksopplysninger(
             fødselsdato = personopplysninger.fødselsdato,
-            // TODO John + Anders: Vurder på hvilket tidspunkt denne kan gjøres om til en liste. Kan det vente til vi har slettet vilkårssettet?
-            tiltaksdeltagelse = overlappendeTiltak.single(),
+            tiltaksdeltagelse = overlappendeTiltak,
         )
     }
 }

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/SakMother.kt
@@ -65,7 +65,7 @@ interface SakMother {
         registrerteTiltak: List<Tiltaksdeltagelse> = listOf(søknad.tiltak.toTiltak()),
         saksopplysninger: Saksopplysninger = Saksopplysninger(
             fødselsdato = fødselsdato,
-            tiltaksdeltagelse = registrerteTiltak.single(),
+            tiltaksdeltagelse = registrerteTiltak,
         ),
         barnetillegg: Barnetillegg? = null,
     ): Sak {

--- a/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/SaksopplysningerMother.kt
+++ b/test-common/src/main/kotlin/no/nav/tiltakspenger/objectmothers/SaksopplysningerMother.kt
@@ -11,7 +11,7 @@ interface SaksopplysningerMother {
     ): Saksopplysninger {
         return Saksopplysninger(
             fødselsdato = fødselsdato,
-            tiltaksdeltagelse = tiltaksdeltagelse,
+            tiltaksdeltagelse = listOf(tiltaksdeltagelse),
         )
     }
 }


### PR DESCRIPTION
Støtter at tiltaksdeltakelser på saksopplysninger er en liste, og legger til rette for at vi tar vare på hvilke perioder saksbehandler valgte for gitte titlaksdeltakelser hvis det er flere som overlapper. 

Migrerer også dataene i databasen: 
- tiltaksdeltagelser blir en liste på saksopplysninger
- legger tiltaksdeltakelsen fra saksopplysningene inn som periodisert valgt tiltaksdeltakelse på behandlingen

https://trello.com/c/W9ifbenn/1315-st%C3%B8tte-at-vi-f%C3%A5r-flere-tiltak-fra-arena-komet-n%C3%A5r-vi-s%C3%B8ker-opp-et-fnr