### PR TITLE
1315 sender ikke lenger informasjon om tiltaket til datadeling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 val kotlinxCoroutinesVersion = "1.10.1"
 val kotestVersion = "5.9.1"
-val felleslibVersion = "0.0.378"
+val felleslibVersion = "0.0.383"
 val mockkVersion = "1.13.17"
 val ktorVersion = "3.1.1"
 val testContainersVersion = "1.20.5"

--- a/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/datadeling/DatadelingBehandlingJson.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/vedtak/clients/datadeling/DatadelingBehandlingJson.kt
@@ -1,7 +1,6 @@
 package no.nav.tiltakspenger.vedtak.clients.datadeling
 
 import no.nav.tiltakspenger.libs.datadeling.DatadelingBehandlingDTO
-import no.nav.tiltakspenger.libs.datadeling.DatadelingTiltakDTO
 import no.nav.tiltakspenger.libs.json.serialize
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandling
 import no.nav.tiltakspenger.saksbehandling.domene.behandling.Behandlingsstatus
@@ -19,11 +18,6 @@ fun Behandling.toBehandlingJson(): String {
         saksbehandler = saksbehandler,
         beslutter = beslutter,
         iverksattTidspunkt = iverksattTidspunkt,
-        tiltak = DatadelingTiltakDTO(
-            tiltakNavn = tiltaksnavn,
-            eksternTiltakdeltakerId = tiltaksid,
-            gjennomføringId = gjennomføringId,
-        ),
         fnr = fnr.verdi,
         // Skal kun kalles for førstegangsbehandlinger, men det skal sjekkes lenger ut.
         søknadJournalpostId = søknad!!.journalpostId,

--- a/domene/build.gradle.kts
+++ b/domene/build.gradle.kts
@@ -1,6 +1,6 @@
 val kotlinxCoroutinesVersion = "1.10.1"
 val kotestVersion = "5.9.1"
-val felleslibVersion = "0.0.378"
+val felleslibVersion = "0.0.383"
 val mockkVersion = "1.13.17"
 val jacksonVersion = "2.18.3"
 

--- a/test-common/build.gradle.kts
+++ b/test-common/build.gradle.kts
@@ -1,6 +1,6 @@
 val kotlinxCoroutinesVersion = "1.10.1"
 val kotestVersion = "5.9.1"
-val felleslibVersion = "0.0.378"
+val felleslibVersion = "0.0.383"
 
 dependencies {
     api(project(":domene"))


### PR DESCRIPTION
Informasjonen er fjernet fra tiltakspenger-datadeling fordi den ikke var i bruk. 

https://trello.com/c/W9ifbenn/1315-st%C3%B8tte-at-vi-f%C3%A5r-flere-tiltak-fra-arena-komet-n%C3%A5r-vi-s%C3%B8ker-opp-et-fnr