### PR TITLE
logger exceptions i vanlig logg

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
@@ -15,7 +15,6 @@ import no.nav.tiltakspenger.libs.jobber.LeaderPodLookupFeil
 import no.nav.tiltakspenger.libs.jobber.RunCheckFactory
 import no.nav.tiltakspenger.saksbehandling.Configuration.httpPort
 import no.nav.tiltakspenger.saksbehandling.context.ApplicationContext
-import no.nav.tiltakspenger.saksbehandling.felles.sikkerlogg
 import no.nav.tiltakspenger.saksbehandling.jobber.TaskExecutor
 import java.time.Clock
 import kotlin.time.Duration.Companion.minutes
@@ -41,8 +40,7 @@ internal fun start(
     devRoutes: Route.(applicationContext: ApplicationContext) -> Unit = {},
 ) {
     Thread.setDefaultUncaughtExceptionHandler { _, e ->
-        log.error { e }
-        sikkerlogg.error(e) { e.message }
+        log.error(e) { e.message }
     }
 
     val server = embeddedServer(


### PR DESCRIPTION
Siden fnr uansett maskeres i vanlig logg er det mye mer praktisk å logge exceptions i vanlig logg, i tillegg til at vi ikke må inn i sikker logg der vi risikerer å se sensitive opplysninger vi ikke har behov for hver gang vi skal sjekke en feilmelding. 