### PR TITLE
Begrunnelse meldekort

### DIFF
--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -49,6 +49,7 @@ sealed interface MeldekortBehandling {
     val navkontor: Navkontor
     val iverksattTidspunkt: LocalDateTime?
     val sendtTilBeslutning: LocalDateTime?
+    val begrunnelse: MeldekortbehandlingBegrunnelse?
 
     /** Denne styres kun av vedtakene. Dersom vi har en åpen meldekortbehandling (inkl. til beslutning) kan et nytt vedtak overstyre hele meldeperioden til [MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER] */
     val ikkeRettTilTiltakspengerTidspunkt: LocalDateTime?
@@ -130,6 +131,7 @@ sealed interface MeldekortBehandling {
         override val brukersMeldekort: BrukersMeldekort?,
         override val meldeperiode: Meldeperiode,
         override val type: MeldekortBehandlingType,
+        override val begrunnelse: MeldekortbehandlingBegrunnelse?,
     ) : MeldekortBehandling {
 
         init {
@@ -210,6 +212,7 @@ sealed interface MeldekortBehandling {
                 brukersMeldekort = brukersMeldekort,
                 meldeperiode = meldeperiode,
                 type = type,
+                begrunnelse = this.begrunnelse,
             )
         }
 
@@ -236,6 +239,7 @@ sealed interface MeldekortBehandling {
         override val meldeperiode: Meldeperiode,
         override val saksbehandler: String,
         override val type: MeldekortBehandlingType,
+        override val begrunnelse: MeldekortbehandlingBegrunnelse?,
     ) : MeldekortBehandling {
         override val iverksattTidspunkt = null
         override val sendtTilBeslutning = null
@@ -250,6 +254,7 @@ sealed interface MeldekortBehandling {
 
         fun sendTilBeslutter(
             utfyltMeldeperiode: MeldeperiodeBeregning.UtfyltMeldeperiode,
+            begrunnelse: MeldekortbehandlingBegrunnelse?,
             saksbehandler: Saksbehandler,
             clock: Clock,
         ): Either<KanIkkeSendeMeldekortTilBeslutning, MeldekortBehandlet> {
@@ -282,6 +287,7 @@ sealed interface MeldekortBehandling {
                 brukersMeldekort = brukersMeldekort,
                 meldeperiode = meldeperiode,
                 type = type,
+                begrunnelse = begrunnelse,
             ).right()
         }
 
@@ -371,5 +377,6 @@ fun Sak.opprettMeldekortBehandling(
             sakId = this.id,
             tiltakstypePerioder = this.vedtaksliste.tiltakstypeperioder,
         ),
+        begrunnelse = null,
     )
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
@@ -76,7 +76,7 @@ data class MeldekortBehandlinger(
         val utfyltMeldeperiode = meldekortUnderBehandling.beregning.tilUtfyltMeldeperiode(meldekortdager).getOrElse {
             return it.left()
         }
-        return meldekortUnderBehandling.sendTilBeslutter(utfyltMeldeperiode, kommando.saksbehandler, clock)
+        return meldekortUnderBehandling.sendTilBeslutter(utfyltMeldeperiode, kommando.meldekortbehandlingBegrunnelse, kommando.saksbehandler, clock)
             .map {
                 Pair(
                     MeldekortBehandlinger(

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingBegrunnelse.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortbehandlingBegrunnelse.kt
@@ -1,0 +1,10 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene
+
+@JvmInline
+value class MeldekortbehandlingBegrunnelse(
+    val verdi: String,
+) {
+    override fun toString(): String {
+        return "*****"
+    }
+}

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/SendMeldekortTilBeslutningKommando.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/SendMeldekortTilBeslutningKommando.kt
@@ -21,6 +21,7 @@ class SendMeldekortTilBeslutningKommando(
     val saksbehandler: Saksbehandler,
     val dager: Dager,
     val correlationId: CorrelationId,
+    val meldekortbehandlingBegrunnelse: MeldekortbehandlingBegrunnelse?,
 ) {
     val periode: Periode = Periode(dager.first().dag, dager.last().dag)
 

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/repository/meldekort/MeldekortBehandlingPostgresRepo.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/repository/meldekort/MeldekortBehandlingPostgresRepo.kt
@@ -17,6 +17,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling.
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling.MeldekortUnderBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlinger
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortbehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.tilMeldekortperioder
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.saksbehandling.domene.sak.Saksnummer
@@ -48,7 +49,8 @@ class MeldekortBehandlingPostgresRepo(
                         iverksatt_tidspunkt,
                         sendt_til_beslutning,
                         navkontor_navn,
-                        type
+                        type,
+                        begrunnelse
                     ) values (
                         :id,
                         :meldeperiode_kjede_id,
@@ -65,7 +67,8 @@ class MeldekortBehandlingPostgresRepo(
                         :iverksatt_tidspunkt,
                         :sendt_til_beslutning,
                         :navkontor_navn,
-                        :type
+                        :type,
+                        :begrunnelse
                     )
                     """,
                     "id" to meldekortBehandling.id.toString(),
@@ -84,6 +87,7 @@ class MeldekortBehandlingPostgresRepo(
                     "sendt_til_beslutning" to meldekortBehandling.sendtTilBeslutning,
                     "navkontor_navn" to meldekortBehandling.navkontor.kontornavn,
                     "type" to meldekortBehandling.type.tilDb(),
+                    "begrunnelse" to meldekortBehandling.begrunnelse?.verdi,
                 ).asUpdate,
             )
         }
@@ -105,7 +109,8 @@ class MeldekortBehandlingPostgresRepo(
                         navkontor = :navkontor,
                         iverksatt_tidspunkt = :iverksatt_tidspunkt,
                         sendt_til_beslutning = :sendt_til_beslutning,
-                        meldeperiode_id = :meldeperiode_id
+                        meldeperiode_id = :meldeperiode_id,
+                        begrunnelse = :begrunnelse
                     where id = :id
                     """,
                     "id" to meldekortBehandling.id.toString(),
@@ -117,6 +122,7 @@ class MeldekortBehandlingPostgresRepo(
                     "iverksatt_tidspunkt" to meldekortBehandling.iverksattTidspunkt,
                     "sendt_til_beslutning" to meldekortBehandling.sendtTilBeslutning,
                     "meldeperiode_id" to meldekortBehandling.meldeperiode.id.toString(),
+                    "begrunnelse" to meldekortBehandling.begrunnelse?.verdi,
                 ).asUpdate,
             )
         }
@@ -189,6 +195,7 @@ class MeldekortBehandlingPostgresRepo(
             val maksDagerMedTiltakspengerForPeriode = meldeperiode.antallDagerForPeriode
             val opprettet = row.localDateTime("opprettet")
             val type = row.string("type").tilMeldekortBehandlingType()
+            val begrunnelse = row.stringOrNull("begrunnelse")?.let { MeldekortbehandlingBegrunnelse(verdi = it) }
 
             val navkontor = Navkontor(kontornummer = navkontorEnhetsnummer, kontornavn = navkontorNavn)
 
@@ -224,6 +231,7 @@ class MeldekortBehandlingPostgresRepo(
                         brukersMeldekort = brukersMeldekort,
                         meldeperiode = meldeperiode,
                         type = type,
+                        begrunnelse = begrunnelse,
                     )
                 }
                 // TODO jah: Her blander vi sammen behandlingsstatus og om man har rett/ikke-rett. Det er mulig at man har startet en meldekortbehandling også endres statusen til IKKE_RETT_TIL_TILTAKSPENGER. Da vil behandlingen sånn som koden er nå implisitt avsluttes. Det kan hende vi bør endre dette når vi skiller grunnlag, innsending og behandling.
@@ -246,6 +254,7 @@ class MeldekortBehandlingPostgresRepo(
                         meldeperiode = meldeperiode,
                         saksbehandler = saksbehandler,
                         type = type,
+                        begrunnelse = begrunnelse,
                     )
                 }
             }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/SendMeldekortTilBeslutterRoute.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/SendMeldekortTilBeslutterRoute.kt
@@ -23,6 +23,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeSendeMeldekor
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeSendeMeldekortTilBeslutning.KunneIkkeHenteSak
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeSendeMeldekortTilBeslutning.MeldekortperiodenKanIkkeVæreFremITid
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeSendeMeldekortTilBeslutning.MåVæreSaksbehandler
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortbehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.SendMeldekortTilBeslutningKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.SendMeldekortTilBeslutningKommando.Dager
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.SendMeldekortTilBeslutningService
@@ -37,6 +38,7 @@ import java.time.LocalDate
 
 private data class Body(
     val dager: List<Dag>,
+    val begrunnelse: String? = null,
 ) {
     data class Dag(
         val dato: String,
@@ -73,6 +75,7 @@ private data class Body(
                 }.toNonEmptyListOrNull()!!,
             ),
             meldekortId = meldekortId,
+            meldekortbehandlingBegrunnelse = begrunnelse?.let { MeldekortbehandlingBegrunnelse(verdi = it) },
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/dto/MeldekortBehandlingDTO.kt
+++ b/app/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/dto/MeldekortBehandlingDTO.kt
@@ -16,6 +16,7 @@ data class MeldekortBehandlingDTO(
     val dager: List<MeldekortDagDTO>,
     val brukersMeldekortId: String?,
     val type: MeldekortBehandlingTypeDTO,
+    val begrunnelse: String?,
 )
 
 fun MeldekortBehandlinger.toDTO(): List<MeldekortBehandlingDTO> {
@@ -38,5 +39,6 @@ fun MeldekortBehandling.toDTO(): MeldekortBehandlingDTO {
         dager = beregning.toDTO(),
         brukersMeldekortId = brukersMeldekort?.id.toString(),
         type = type.tilDTO(),
+        begrunnelse = begrunnelse?.verdi,
     )
 }

--- a/app/src/main/resources/db/migration/V57__meldekortbehandling_begrunnelse.sql
+++ b/app/src/main/resources/db/migration/V57__meldekortbehandling_begrunnelse.sql
@@ -1,0 +1,1 @@
+ALTER TABLE meldekortbehandling ADD COLUMN IF NOT EXISTS begrunnelse VARCHAR;

--- a/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
@@ -31,6 +31,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingType
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlinger
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortbehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.Meldeperiode
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldeperiodeBeregning
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldeperiodeBeregningDag
@@ -90,6 +91,7 @@ interface MeldekortMother : MotherOfAllMothers {
             brukersMeldekort = null,
             saksbehandler = saksbehandler,
             type = type,
+            begrunnelse = null,
         )
     }
 
@@ -129,6 +131,7 @@ interface MeldekortMother : MotherOfAllMothers {
         sendtTilBeslutning: LocalDateTime = nå(clock),
         erFørsteBehandlingForPerioden: Boolean = true,
         type: MeldekortBehandlingType = MeldekortBehandlingType.FØRSTE_BEHANDLING,
+        begrunnelse: MeldekortbehandlingBegrunnelse? = null,
     ): MeldekortBehandling.MeldekortBehandlet {
         return MeldekortBehandling.MeldekortBehandlet(
             id = id,
@@ -147,6 +150,7 @@ interface MeldekortMother : MotherOfAllMothers {
             meldeperiode = meldeperiode,
             brukersMeldekort = null,
             type = type,
+            begrunnelse = begrunnelse,
         )
     }
 
@@ -274,6 +278,7 @@ interface MeldekortMother : MotherOfAllMothers {
         ),
         navkontor: Navkontor = ObjectMother.navkontor(),
         barnetilleggsPerioder: Periodisering<AntallBarn?> = Periodisering.empty(),
+        begrunnelse: MeldekortbehandlingBegrunnelse? = null,
     ): MeldekortBehandlinger {
         val kommandoer = meldeperioder.map { meldeperiode ->
             SendMeldekortTilBeslutningKommando(
@@ -282,6 +287,7 @@ interface MeldekortMother : MotherOfAllMothers {
                 saksbehandler = saksbehandler,
                 dager = Dager(meldeperiode),
                 correlationId = CorrelationId.generate(),
+                meldekortbehandlingBegrunnelse = begrunnelse,
             )
         }
 
@@ -319,6 +325,7 @@ interface MeldekortMother : MotherOfAllMothers {
         barnetilleggsPerioder: Periodisering<AntallBarn?> = Periodisering.empty(),
         girRett: Map<LocalDate, Boolean> = kommando.dager.dager.map { it.dag to it.status.girRett() }.toMap(),
         antallDagerForPeriode: Int = girRett.count { it.value },
+        begrunnelse: MeldekortbehandlingBegrunnelse? = null,
     ): Pair<MeldekortBehandlinger, MeldekortBehandling.MeldekortBehandlet> {
         val meldeperiode = meldeperiode(
             periode = kommando.periode,
@@ -351,6 +358,7 @@ interface MeldekortMother : MotherOfAllMothers {
                     brukersMeldekort = null,
                     saksbehandler = kommando.saksbehandler.navIdent,
                     type = MeldekortBehandlingType.FØRSTE_BEHANDLING,
+                    begrunnelse = begrunnelse,
                 ),
             ),
         )
@@ -405,6 +413,7 @@ interface MeldekortMother : MotherOfAllMothers {
                 brukersMeldekort = null,
                 saksbehandler = kommando.saksbehandler.navIdent,
                 type = MeldekortBehandlingType.FØRSTE_BEHANDLING,
+                begrunnelse = null,
             ),
         ).sendTilBeslutter(kommando, barnetilleggsPerioder, tiltakstypePerioder, clock).getOrFail().first
     }
@@ -539,5 +548,6 @@ fun MeldekortBehandling.MeldekortUnderBehandling.tilSendMeldekortTilBeslutterKom
         saksbehandler = saksbehandler,
         dager = Dager(dager),
         correlationId = CorrelationId.generate(),
+        meldekortbehandlingBegrunnelse = null,
     )
 }

--- a/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/repository/meldekort/MeldekortBehandlingRepoImplTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/repository/meldekort/MeldekortBehandlingRepoImplTest.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.libs.periodisering.mars
 import no.nav.tiltakspenger.saksbehandling.db.persisterIverksattFørstegangsbehandling
 import no.nav.tiltakspenger.saksbehandling.db.withMigratedDb
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlinger
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortbehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.opprettMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
 import org.junit.jupiter.api.Test
@@ -31,6 +32,7 @@ class MeldekortBehandlingRepoImplTest {
                 saksnummer = sak.saksnummer,
                 meldeperiode = sak.meldeperiodeKjeder.first().first(),
                 periode = sak.meldeperiodeKjeder.first().first().periode,
+                begrunnelse = MeldekortbehandlingBegrunnelse("begrunnelse"),
             ).also { meldekortRepo.lagre(it) }
 
             testDataHelper.sessionFactory.withSession {
@@ -84,6 +86,7 @@ class MeldekortBehandlingRepoImplTest {
                 ),
                 saksbehandler = ObjectMother.saksbehandler(),
                 clock = fixedClock,
+                begrunnelse = null,
             ).getOrFail()
 
             meldekortRepo.oppdater(oppdatertMeldekortBehandling)

--- a/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/SendMeldekortBehandlingTilBeslutterRouteTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/routes/meldekort/SendMeldekortBehandlingTilBeslutterRouteTest.kt
@@ -46,7 +46,6 @@ internal class SendMeldekortBehandlingTilBeslutterRouteTest {
         } returns KanIkkeSendeMeldekortTilBeslutning.ForMangeDagerUtfylt(14, 15).left()
         val request = """
             {
-              "navkontor": "0315",
               "dager": [
                 {"dato":"2024-01-01","status":"FRAVÆR_SYK"}
               ]

--- a/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/SendMeldekortBehandlingTilBeslutterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/SendMeldekortBehandlingTilBeslutterServiceTest.kt
@@ -46,6 +46,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 ),
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ) shouldBe KanIkkeSendeMeldekortTilBeslutning.InnsendteDagerMåMatcheMeldeperiode.left()
             }
@@ -90,6 +91,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 IKKE_DELTATT,
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ) shouldBe KanIkkeSendeMeldekortTilBeslutning.InnsendteDagerMåMatcheMeldeperiode.left()
             }
@@ -134,6 +136,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 SPERRET,
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ) shouldBe KanIkkeSendeMeldekortTilBeslutning.InnsendteDagerMåMatcheMeldeperiode.left()
             }
@@ -177,6 +180,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 SPERRET,
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ) shouldBe KanIkkeSendeMeldekortTilBeslutning.KanIkkeEndreDagTilSperret.left()
             }
@@ -221,6 +225,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 DELTATT_UTEN_LØNN_I_TILTAKET,
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ) shouldBe KanIkkeSendeMeldekortTilBeslutning.KanIkkeEndreDagFraSperret.left()
             }
@@ -264,6 +269,7 @@ internal class SendMeldekortBehandlingTilBeslutterServiceTest {
                                 IKKE_DELTATT,
                             ),
                         ),
+                        meldekortbehandlingBegrunnelse = null,
                     ),
                 ).getOrFail()
             }


### PR DESCRIPTION
Legger til mulighet for begrunnelse for meldekort for saksbehandler

https://trello.com/c/xKq1PSBo/1398-meldekortbehandling-legg-til-begrunnelsesfelt-som-vises-i-oppsummering-og-til-beslutter