### PR TITLE
1430 lagrer relevante identhendelser fra pdl

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
@@ -26,7 +26,9 @@ import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.VeilarboppfolgingGateway
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.infra.http.VeilarboppfolgingHttpClient
 import no.nav.tiltakspenger.saksbehandling.oppgave.infra.OppgaveHttpClient
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.IdenthendelseService
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.AktorV2Consumer
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseRepository
 import no.nav.tiltakspenger.saksbehandling.person.infra.setup.PersonContext
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.PersonhendelseService
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.jobb.PersonhendelseJobb
@@ -146,6 +148,19 @@ open class ApplicationContext(
         )
     }
 
+    open val identhendelseRepository: IdenthendelseRepository by lazy {
+        IdenthendelseRepository(
+            sessionFactory = sessionFactory as PostgresSessionFactory,
+        )
+    }
+
+    open val identhendelseService: IdenthendelseService by lazy {
+        IdenthendelseService(
+            sakRepo = sakContext.sakRepo,
+            identhendelseRepository = identhendelseRepository,
+        )
+    }
+
     open val leesahConsumer by lazy {
         LeesahConsumer(
             topic = Configuration.leesahTopic,
@@ -164,6 +179,7 @@ open class ApplicationContext(
     open val aktorV2Consumer by lazy {
         AktorV2Consumer(
             topic = Configuration.aktorV2Topic,
+            identhendelseService = identhendelseService,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/IdenthendelseService.kt
@@ -1,0 +1,78 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.person.pdl.aktor.v2.Aktor
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.logging.sikkerlogg
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.SakRepo
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseDb
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseRepository
+import java.util.UUID
+
+class IdenthendelseService(
+    private val sakRepo: SakRepo,
+    private val identhendelseRepository: IdenthendelseRepository,
+) {
+    private val log = KotlinLogging.logger { }
+
+    fun behandleIdenthendelse(aktor: Aktor) {
+        try {
+            val personidenter = aktor.identifikatorer.map { it.toPersonident() }
+            val gjeldendeIdent = finnGjeldendeIdent(personidenter)
+            val nyttFnr = Fnr.tryFromString(gjeldendeIdent.ident)
+            if (nyttFnr == null) {
+                sikkerlogg.error { "Ny ident er ikke gyldig fnr: ${gjeldendeIdent.ident}" }
+                throw IllegalArgumentException("Ny ident må være gyldig fnr")
+            }
+
+            val historiskeFnrOgNpid = personidenter.filter { it.historisk && it.identtype != Identtype.AKTORID }
+
+            var antallSaker = 0
+            if (sakRepo.hentForFnr(nyttFnr).saker.isNotEmpty()) {
+                log.warn { "Fant sak på nytt fnr" }
+                antallSaker += 1
+            }
+            historiskeFnrOgNpid.forEach {
+                val fnr = Fnr.tryFromString(it.ident) ?: return@forEach
+                val saker = sakRepo.hentForFnr(fnr)
+                if (saker.saker.isNotEmpty()) {
+                    antallSaker += 1
+                    if (antallSaker > 1) {
+                        log.error { "Fant flere saker knyttet til samme nye fnr, kan ikke behandle identendringen. Se sikkerlogg for mer informasjon" }
+                        sikkerlogg.error { "Fant flere saker knyttet til samme nye fnr, kan ikke behandle identendringen: $personidenter" }
+                        throw IllegalStateException("Fant flere saker knyttet til samme nye fnr, kan ikke behandle identendringen")
+                    }
+                    val sak = saker.saker.single()
+                    val identhendelseDb = IdenthendelseDb(
+                        id = UUID.randomUUID(),
+                        gammeltFnr = fnr,
+                        nyttFnr = nyttFnr,
+                        personidenter = personidenter,
+                        sakId = sak.id,
+                        produsertHendelse = null,
+                        oppdatertDatabase = null,
+                    )
+                    identhendelseRepository.lagre(identhendelseDb)
+                    log.info { "Lagret identhendelse med id ${identhendelseDb.id}" }
+                }
+            }
+        } catch (e: Exception) {
+            log.error(e) { "Noe gikk galt ved håndtering av identhendelse" }
+            throw e
+        }
+    }
+
+    private fun finnGjeldendeIdent(personidenter: List<Personident>): Personident {
+        val gjeldendeIdent = personidenter.firstOrNull {
+            !it.historisk && it.identtype == Identtype.FOLKEREGISTERIDENT
+        } ?: personidenter.firstOrNull {
+            !it.historisk && it.identtype == Identtype.NPID
+        }
+        if (gjeldendeIdent == null) {
+            log.error { "Kan ikke behandle identhendelse uten gjeldende ident, se sikkerlogg for mer informasjon" }
+            sikkerlogg.error { "Kan ikke behandle identhendelse uten gjeldende ident: $personidenter" }
+            throw IllegalArgumentException("Kan ikke behandle identhendelse uten gjeldende ident")
+        }
+        return gjeldendeIdent
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/Personident.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/Personident.kt
@@ -1,0 +1,31 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser
+
+import no.nav.person.pdl.aktor.v2.Identifikator
+import no.nav.person.pdl.aktor.v2.Type
+
+data class Personident(
+    val ident: String,
+    val historisk: Boolean,
+    val identtype: Identtype,
+)
+
+enum class Identtype {
+    FOLKEREGISTERIDENT,
+    NPID,
+    AKTORID,
+}
+
+fun Identifikator.toPersonident() =
+    Personident(
+        ident = idnummer,
+        historisk = !gjeldende,
+        identtype = type.toIdenttype(),
+    )
+
+private fun Type.toIdenttype(): Identtype {
+    return when (this) {
+        Type.FOLKEREGISTERIDENT -> Identtype.FOLKEREGISTERIDENT
+        Type.NPID -> Identtype.NPID
+        Type.AKTORID -> Identtype.AKTORID
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/repo/IdenthendelseDb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/repo/IdenthendelseDb.kt
@@ -1,0 +1,17 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo
+
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.Personident
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class IdenthendelseDb(
+    val id: UUID,
+    val gammeltFnr: Fnr,
+    val nyttFnr: Fnr,
+    val personidenter: List<Personident>,
+    val sakId: SakId,
+    val produsertHendelse: LocalDateTime?,
+    val oppdatertDatabase: LocalDateTime?,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/repo/IdenthendelseRepository.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/repo/IdenthendelseRepository.kt
@@ -1,0 +1,80 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.json.objectMapper
+import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
+import no.nav.tiltakspenger.saksbehandling.infra.repo.toPGObject
+import org.intellij.lang.annotations.Language
+import java.time.LocalDateTime
+
+class IdenthendelseRepository(
+    private val sessionFactory: PostgresSessionFactory,
+) {
+    fun lagre(identhendelseDb: IdenthendelseDb) {
+        sessionFactory.withSession { session ->
+            session.run(
+                queryOf(
+                    lagreIdenthendelse,
+                    mapOf(
+                        "id" to identhendelseDb.id,
+                        "gammelt_fnr" to identhendelseDb.gammeltFnr.verdi,
+                        "nytt_fnr" to identhendelseDb.nyttFnr.verdi,
+                        "personidenter" to toPGObject(identhendelseDb.personidenter),
+                        "sak_id" to identhendelseDb.sakId.toString(),
+                        "produsert_hendelse" to identhendelseDb.produsertHendelse,
+                        "oppdatert_database" to identhendelseDb.oppdatertDatabase,
+                        "sist_oppdatert" to LocalDateTime.now(),
+                    ),
+                ).asUpdate,
+            )
+        }
+    }
+
+    fun hent(gammeltFnr: Fnr): List<IdenthendelseDb> = sessionFactory.withSession {
+        it.run(
+            queryOf(sqlHentForGammeltFnr, gammeltFnr.verdi)
+                .map { row -> row.toIdenthendelseDb() }
+                .asList,
+        )
+    }
+
+    private fun Row.toIdenthendelseDb() =
+        IdenthendelseDb(
+            id = uuid("id"),
+            gammeltFnr = Fnr.fromString(string("gammelt_fnr")),
+            nyttFnr = Fnr.fromString(string("nytt_fnr")),
+            personidenter = objectMapper.readValue(string("personidenter")),
+            sakId = SakId.fromString(string("sak_id")),
+            produsertHendelse = localDateTimeOrNull("produsert_hendelse"),
+            oppdatertDatabase = localDateTimeOrNull("oppdatert_database"),
+        )
+
+    @Language("SQL")
+    private val lagreIdenthendelse =
+        """
+        insert into identhendelse (
+            id,
+            gammelt_fnr,
+            nytt_fnr,
+            personidenter,
+            sak_id,
+            produsert_hendelse,
+            oppdatert_database
+        ) values (
+            :id,
+            :gammelt_fnr,
+            :nytt_fnr,
+            :personidenter,
+            :sak_id,
+            :produsert_hendelse,
+            :oppdatert_database
+        )
+        """.trimIndent()
+
+    @Language("SQL")
+    private val sqlHentForGammeltFnr = "select * from identhendelse where gammelt_fnr = ?"
+}

--- a/src/main/resources/db/migration/V71__create_table_identhendelse.sql
+++ b/src/main/resources/db/migration/V71__create_table_identhendelse.sql
@@ -1,0 +1,15 @@
+CREATE TABLE identhendelse
+(
+    id                 uuid PRIMARY KEY,
+    gammelt_fnr        varchar                                            not null,
+    nytt_fnr           varchar                                            not null,
+    personidenter      jsonb                                              not null,
+    sak_id             varchar                                            NOT NULL REFERENCES sak (id),
+    produsert_hendelse timestamp with time zone,
+    oppdatert_database timestamp with time zone,
+    opprettet          timestamp with time zone default CURRENT_TIMESTAMP not null,
+    sist_oppdatert     timestamp with time zone default CURRENT_TIMESTAMP not null
+);
+
+CREATE INDEX idx_identhendelse_produsert_hendelse ON identhendelse (produsert_hendelse);
+CREATE INDEX idx_identhendelse_oppdatert_database ON identhendelse (oppdatert_database);

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.saksbehandling.common.TestSaksnummerGenerator
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.repo.BrukersMeldekortPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.repo.MeldekortBehandlingPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.repo.MeldeperiodePostgresRepo
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseRepository
 import no.nav.tiltakspenger.saksbehandling.person.infra.repo.PersonPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.repo.PersonhendelseRepository
 import no.nav.tiltakspenger.saksbehandling.sak.infra.repo.SakPostgresRepo
@@ -45,6 +46,7 @@ internal class TestDataHelper(
     val personRepo = PersonPostgresRepo(sessionFactory)
     val tiltaksdeltakerKafkaRepository = TiltaksdeltakerKafkaRepository(sessionFactory)
     val personhendelseRepository = PersonhendelseRepository(sessionFactory)
+    val identhendelseRepository = IdenthendelseRepository(sessionFactory)
 }
 
 private val dbManager = TestDatabaseManager()

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDatabaseManager.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDatabaseManager.kt
@@ -86,6 +86,7 @@ internal class TestDatabaseManager {
                 TRUNCATE
                   tiltaksdeltaker_kafka,
                   personhendelse,
+                  identhendelse,
                   utbetalingsvedtak,
                   statistikk_utbetaling,
                   statistikk_stonad,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/IdenthendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/IdenthendelseServiceTest.kt
@@ -1,0 +1,184 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import no.nav.person.pdl.aktor.v2.Aktor
+import no.nav.person.pdl.aktor.v2.Identifikator
+import no.nav.person.pdl.aktor.v2.Type
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.random
+import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterSakOgSøknad
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMigratedDb
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class IdenthendelseServiceTest {
+    @Test
+    fun `behandleIdenthendelse - finnes ingen sak - ignorerer`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakPostgresRepo = testDataHelper.sakRepo
+                val identhendelseService = IdenthendelseService(sakPostgresRepo, identhendelseRepository)
+                val gammeltFnr = Fnr.random()
+
+                identhendelseService.behandleIdenthendelse(
+                    Aktor(
+                        listOf(
+                            Identifikator(Fnr.random().verdi, Type.FOLKEREGISTERIDENT, true),
+                            Identifikator(gammeltFnr.verdi, Type.FOLKEREGISTERIDENT, false),
+                            Identifikator("1234567890123", Type.AKTORID, true),
+                        ),
+                    ),
+                )
+
+                identhendelseRepository.hent(gammeltFnr) shouldBe emptyList()
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelse - finnes en sak - lagrer`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakPostgresRepo = testDataHelper.sakRepo
+                val identhendelseService = IdenthendelseService(sakPostgresRepo, identhendelseRepository)
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+                val sak = ObjectMother.nySak(fnr = gammeltFnr)
+                testDataHelper.persisterSakOgSøknad(
+                    fnr = gammeltFnr,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = gammeltFnr),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+
+                identhendelseService.behandleIdenthendelse(
+                    Aktor(
+                        listOf(
+                            Identifikator(nyttFnr.verdi, Type.FOLKEREGISTERIDENT, true),
+                            Identifikator(gammeltFnr.verdi, Type.FOLKEREGISTERIDENT, false),
+                            Identifikator("1234567890123", Type.AKTORID, true),
+                        ),
+                    ),
+                )
+
+                val identhendelseDb = identhendelseRepository.hent(gammeltFnr).first()
+                identhendelseDb.gammeltFnr shouldBe gammeltFnr
+                identhendelseDb.nyttFnr shouldBe nyttFnr
+                identhendelseDb.sakId shouldBe sak.id
+                identhendelseDb.produsertHendelse shouldBe null
+                identhendelseDb.oppdatertDatabase shouldBe null
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelse - finnes sak på nytt fnr - ignorerer`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakPostgresRepo = testDataHelper.sakRepo
+                val identhendelseService = IdenthendelseService(sakPostgresRepo, identhendelseRepository)
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+                val sak = ObjectMother.nySak(fnr = nyttFnr)
+                testDataHelper.persisterSakOgSøknad(
+                    fnr = nyttFnr,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = nyttFnr),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+
+                identhendelseService.behandleIdenthendelse(
+                    Aktor(
+                        listOf(
+                            Identifikator(nyttFnr.verdi, Type.FOLKEREGISTERIDENT, true),
+                            Identifikator(gammeltFnr.verdi, Type.FOLKEREGISTERIDENT, false),
+                            Identifikator("1234567890123", Type.AKTORID, true),
+                        ),
+                    ),
+                )
+
+                identhendelseRepository.hent(gammeltFnr) shouldBe emptyList()
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelse - finnes sak på nytt og gammelt fnr - feiler`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakPostgresRepo = testDataHelper.sakRepo
+                val identhendelseService = IdenthendelseService(sakPostgresRepo, identhendelseRepository)
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+                val sak = ObjectMother.nySak(fnr = gammeltFnr)
+                testDataHelper.persisterSakOgSøknad(
+                    fnr = gammeltFnr,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = gammeltFnr),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+                val sak2 = ObjectMother.nySak(fnr = nyttFnr, saksnummer = Saksnummer.genererSaknummer(løpenr = "1000"))
+                testDataHelper.persisterSakOgSøknad(
+                    fnr = nyttFnr,
+                    sak = sak2,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = nyttFnr),
+                        sakId = sak2.id,
+                        saksnummer = sak2.saksnummer,
+                    ),
+                )
+
+                assertFailsWith<IllegalStateException> {
+                    identhendelseService.behandleIdenthendelse(
+                        Aktor(
+                            listOf(
+                                Identifikator(nyttFnr.verdi, Type.FOLKEREGISTERIDENT, true),
+                                Identifikator(gammeltFnr.verdi, Type.FOLKEREGISTERIDENT, false),
+                                Identifikator("1234567890123", Type.AKTORID, true),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelse - ingen gjeldende ident - feiler`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakPostgresRepo = testDataHelper.sakRepo
+                val identhendelseService = IdenthendelseService(sakPostgresRepo, identhendelseRepository)
+
+                assertFailsWith<IllegalArgumentException> {
+                    identhendelseService.behandleIdenthendelse(
+                        Aktor(
+                            listOf(
+                                Identifikator(Fnr.random().verdi, Type.FOLKEREGISTERIDENT, false),
+                                Identifikator(Fnr.random().verdi, Type.FOLKEREGISTERIDENT, false),
+                                Identifikator("1234567890123", Type.AKTORID, true),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Lagrer identendringer hvis vi har en sak på en av de gamle identene. Disse skal plukkes opp av en jobb senere. Hvis vi har (eller vil få) flere saker på samme fnr lar vi innlesingen feile, for da må vi se hva som har skjedd så vi ikke havner i en tilstand der vi får flere saker pr fnr før vi evt støtter det. 

https://trello.com/c/Ck4Sc5nT/1430-hvis-bruker-som-finnes-i-v%C3%A5rt-system-endrer-fnr-s%C3%A5-skal-vi-oppdatere-alle-steder-der-vi-har-lagret-fnr