### PR TITLE
Behandle identhendelse

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/App.kt
@@ -94,6 +94,7 @@ internal fun start(
                         { applicationContext.meldekortContext.sendMeldeperiodeTilBrukerService.send() },
                         { applicationContext.personhendelseJobb.opprettOppgaveForPersonhendelser() },
                         { applicationContext.personhendelseJobb.opprydning() },
+                        { applicationContext.identhendelseJobb.behandleIdenthendelser() },
                     ),
                 )
             } else {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/SakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/SakRepo.kt
@@ -49,4 +49,6 @@ interface SakRepo {
     )
 
     fun hentSakerSomMåGenerereMeldeperioderFra(ikkeGenererEtter: LocalDate, limit: Int = 1000): List<SakId>
+
+    fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkSakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkSakRepo.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.saksbehandling.behandling.ports
 
+import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.StatistikkSakDTO
@@ -8,4 +9,5 @@ interface StatistikkSakRepo {
     fun lagre(dto: StatistikkSakDTO, context: TransactionContext? = null)
     fun oppdaterAdressebeskyttelse(sakId: SakId)
     fun hent(sakId: SakId): List<StatistikkSakDTO>
+    fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkStønadRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkStønadRepo.kt
@@ -1,5 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.behandling.ports
 
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkStønadDTO
 import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkUtbetalingDTO
@@ -7,4 +9,6 @@ import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad
 interface StatistikkStønadRepo {
     fun lagre(dto: StatistikkStønadDTO, context: TransactionContext? = null)
     fun lagre(dto: StatistikkUtbetalingDTO, context: TransactionContext? = null)
+    fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr)
+    fun hent(sakId: SakId): List<StatistikkStønadDTO>
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/SøknadRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/SøknadRepo.kt
@@ -21,4 +21,6 @@ interface SøknadRepo {
     fun finnSakIdForTiltaksdeltakelse(eksternId: String): SakId?
 
     fun lagreAvbruttSøknad(søknad: Søknad, txContext: TransactionContext? = null)
+
+    fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
@@ -8,6 +8,8 @@ import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.libs.common.GenerellSystembruker
 import no.nav.tiltakspenger.libs.common.GenerellSystembrukerrolle
 import no.nav.tiltakspenger.libs.common.GenerellSystembrukerroller
+import no.nav.tiltakspenger.libs.kafka.Producer
+import no.nav.tiltakspenger.libs.kafka.config.KafkaConfigImpl
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.SessionCounter
@@ -27,7 +29,9 @@ import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.VeilarboppfolgingGa
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.infra.http.VeilarboppfolgingHttpClient
 import no.nav.tiltakspenger.saksbehandling.oppgave.infra.OppgaveHttpClient
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.IdenthendelseService
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.jobb.IdenthendelseJobb
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.AktorV2Consumer
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseKafkaProducer
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseRepository
 import no.nav.tiltakspenger.saksbehandling.person.infra.setup.PersonContext
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.PersonhendelseService
@@ -180,6 +184,24 @@ open class ApplicationContext(
         AktorV2Consumer(
             topic = Configuration.aktorV2Topic,
             identhendelseService = identhendelseService,
+        )
+    }
+
+    open val identhendelseKafkaProducer by lazy {
+        IdenthendelseKafkaProducer(
+            kafkaProducer = Producer(KafkaConfigImpl()),
+            topic = Configuration.identhendelseTopic,
+        )
+    }
+
+    open val identhendelseJobb by lazy {
+        IdenthendelseJobb(
+            identhendelseRepository = identhendelseRepository,
+            identhendelseKafkaProducer = identhendelseKafkaProducer,
+            sakRepo = sakContext.sakRepo,
+            søknadRepo = søknadContext.søknadRepo,
+            statistikkSakRepo = statistikkContext.statistikkSakRepo,
+            statistikkStønadRepo = statistikkContext.statistikkStønadRepo,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/Configuration.kt
@@ -93,6 +93,7 @@ object Configuration {
                 "KOMET_TILTAKSDELTAKER_TOPIC" to "komet.tiltaksdeltaker",
                 "LEESAH_TOPIC" to "pdl.leesah",
                 "AKTOR_V2_TOPIC" to "pdl.aktor",
+                "IDENTHENDELSE_TOPIC" to "tpts.identhendelse",
             ),
         )
 
@@ -132,6 +133,7 @@ object Configuration {
                 "KOMET_TILTAKSDELTAKER_TOPIC" to "amt.deltaker-v1",
                 "LEESAH_TOPIC" to "pdl.leesah-v1",
                 "AKTOR_V2_TOPIC" to "pdl.aktor-v2",
+                "IDENTHENDELSE_TOPIC" to "tpts.identhendelse-v1",
             ),
         )
     private val prodProperties =
@@ -170,6 +172,7 @@ object Configuration {
                 "KOMET_TILTAKSDELTAKER_TOPIC" to "amt.deltaker-v1",
                 "LEESAH_TOPIC" to "pdl.leesah-v1",
                 "AKTOR_V2_TOPIC" to "pdl.aktor-v2",
+                "IDENTHENDELSE_TOPIC" to "tpts.identhendelse-v1",
             ),
         )
 
@@ -255,6 +258,7 @@ object Configuration {
     val kometTiltaksdeltakerTopic: String by lazy { config()[Key("KOMET_TILTAKSDELTAKER_TOPIC", stringType)] }
     val leesahTopic: String by lazy { config()[Key("LEESAH_TOPIC", stringType)] }
     val aktorV2Topic: String by lazy { config()[Key("AKTOR_V2_TOPIC", stringType)] }
+    val identhendelseTopic: String by lazy { config()[Key("IDENTHENDELSE_TOPIC", stringType)] }
 
     fun httpPort() = config()[Key("application.httpPort", intType)]
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobb.kt
@@ -1,0 +1,62 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser.jobb
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.SakRepo
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.SøknadRepo
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseDto
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseKafkaProducer
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseDb
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseRepository
+
+class IdenthendelseJobb(
+    private val identhendelseRepository: IdenthendelseRepository,
+    private val identhendelseKafkaProducer: IdenthendelseKafkaProducer,
+    private val sakRepo: SakRepo,
+    private val søknadRepo: SøknadRepo,
+    private val statistikkSakRepo: StatistikkSakRepo,
+    private val statistikkStønadRepo: StatistikkStønadRepo,
+
+) {
+    private val log = KotlinLogging.logger {}
+
+    fun behandleIdenthendelser() {
+        val identhendelser = identhendelseRepository.hentAlleSomIkkeErBehandlet()
+        identhendelser.forEach { identhendelse ->
+            try {
+                if (identhendelse.produsertHendelse == null) {
+                    identhendelseKafkaProducer.produserIdenthendelse(identhendelse.id, identhendelse.toIdenthendelseDto())
+                    identhendelseRepository.oppdaterProdusertHendelse(identhendelse.id)
+                    log.info { "Oppdatert produsert_hendelse for identhendelse med id ${identhendelse.id}" }
+                }
+
+                val harProdusertHendelse = identhendelse.produsertHendelse != null || identhendelseRepository.hent(identhendelse.id)?.produsertHendelse != null
+                if (harProdusertHendelse && identhendelse.oppdatertDatabase == null) {
+                    oppdaterFnr(
+                        gammeltFnr = identhendelse.gammeltFnr,
+                        nyttFnr = identhendelse.nyttFnr,
+                    )
+                    identhendelseRepository.oppdaterOppdatertDatabase(identhendelse.id)
+                    log.info { "Oppdatert oppdatert_database for identhendelse med id ${identhendelse.id}" }
+                }
+            } catch (e: Exception) {
+                log.error(e) { "Noe gikk galt ved behandling av identhendelse med id ${identhendelse.id}" }
+            }
+        }
+    }
+
+    private fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        sakRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
+        søknadRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
+        statistikkSakRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
+        statistikkStønadRepo.oppdaterFnr(gammeltFnr = gammeltFnr, nyttFnr = nyttFnr)
+    }
+
+    private fun IdenthendelseDb.toIdenthendelseDto() =
+        IdenthendelseDto(
+            gammeltFnr = gammeltFnr.verdi,
+            nyttFnr = nyttFnr.verdi,
+        )
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/kafka/IdenthendelseKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/kafka/IdenthendelseKafkaProducer.kt
@@ -1,0 +1,23 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.libs.json.objectMapper
+import no.nav.tiltakspenger.libs.kafka.Producer
+import java.util.UUID
+
+class IdenthendelseKafkaProducer(
+    private val kafkaProducer: Producer<String, String>,
+    private val topic: String,
+) {
+    private val log = KotlinLogging.logger {}
+
+    fun produserIdenthendelse(id: UUID, identhendelseDto: IdenthendelseDto) {
+        kafkaProducer.produce(topic, id.toString(), objectMapper.writeValueAsString(identhendelseDto))
+        log.info { "Produserte identhendelse med id $id til topic" }
+    }
+}
+
+data class IdenthendelseDto(
+    val gammeltFnr: String,
+    val nyttFnr: String,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/repo/SakPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/repo/SakPostgresRepo.kt
@@ -247,6 +247,22 @@ internal class SakPostgresRepo(
         }
     }
 
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        sessionFactory.withSessionContext { sessionContext ->
+            sessionContext.withSession { session ->
+                session.run(
+                    queryOf(
+                        """update sak set fnr = :nytt_fnr where fnr = :gammelt_fnr""",
+                        mapOf(
+                            "nytt_fnr" to nyttFnr.verdi,
+                            "gammelt_fnr" to gammeltFnr.verdi,
+                        ),
+                    ).asUpdate,
+                )
+            }
+        }
+    }
+
     private fun sakFinnes(
         sakId: SakId,
         session: Session,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/infra/repo/sak/StatistikkSakRepoImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/infra/repo/sak/StatistikkSakRepoImpl.kt
@@ -3,6 +3,7 @@ package no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.sak
 import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.queryOf
+import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
@@ -53,6 +54,22 @@ internal class StatistikkSakRepoImpl(
             ).map { row -> row.toStatistikkSakDTO() }
                 .asList,
         )
+    }
+
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        sessionFactory.withSession {
+            it.run(
+                queryOf(
+                    """
+                        update statistikk_sak set fnr = :nytt_fnr where fnr = :gammelt_fnr
+                    """.trimIndent(),
+                    mapOf(
+                        "nytt_fnr" to nyttFnr.verdi,
+                        "gammelt_fnr" to gammeltFnr.verdi,
+                    ),
+                ).asUpdate,
+            )
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/repo/PostgresSøknadRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/repo/PostgresSøknadRepo.kt
@@ -49,4 +49,14 @@ internal class PostgresSøknadRepo(
             SøknadDAO.lagreAvbruttSøknad(søknad.id, søknad.avbrutt!!, it)
         }
     }
+
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        sessionFactory.withSession {
+            SøknadDAO.oppdaterFnr(
+                gammeltFnr = gammeltFnr,
+                nyttFnr = nyttFnr,
+                session = it,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/repo/SøknadDAO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/repo/SøknadDAO.kt
@@ -169,6 +169,22 @@ internal object SøknadDAO {
         }
     }
 
+    fun oppdaterFnr(
+        gammeltFnr: Fnr,
+        nyttFnr: Fnr,
+        session: Session,
+    ) {
+        session.run(
+            queryOf(
+                """update søknad set fnr = :nytt_fnr where fnr = :gammelt_fnr""",
+                mapOf(
+                    "nytt_fnr" to nyttFnr.verdi,
+                    "gammelt_fnr" to gammeltFnr.verdi,
+                ),
+            ).asUpdate,
+        )
+    }
+
     private fun lagreSøknad(
         søknad: Søknad,
         session: Session,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/SakFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/SakFakeRepo.kt
@@ -108,4 +108,13 @@ class SakFakeRepo(
             return it
         }
     }
+
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        val sak = data.get().values.find { it.fnr == gammeltFnr }
+        sak?.let {
+            data.get()[it.id] = it.copy(
+                fnr = nyttFnr,
+            )
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkSakFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkSakFakeRepo.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.fakes.repos
 
 import arrow.atomic.Atomic
+import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
@@ -26,5 +27,14 @@ class StatistikkSakFakeRepo : StatistikkSakRepo {
 
     override fun hent(sakId: SakId): List<StatistikkSakDTO> {
         return data.get()[sakId]?.let { listOf(it) } ?: emptyList()
+    }
+
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        val statistikkSak = data.get().values.find { it.fnr == gammeltFnr.verdi }
+        statistikkSak?.let {
+            data.get()[SakId.fromString(it.sakId)] = it.copy(
+                fnr = nyttFnr.verdi,
+            )
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkStønadFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkStønadFakeRepo.kt
@@ -1,6 +1,8 @@
 package no.nav.tiltakspenger.saksbehandling.fakes.repos
 
 import arrow.atomic.Atomic
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkStønadDTO
@@ -17,5 +19,18 @@ class StatistikkStønadFakeRepo : StatistikkStønadRepo {
 
     override fun lagre(dto: StatistikkUtbetalingDTO, context: TransactionContext?) {
         utbetalingsdata.get()[dto.id] = dto
+    }
+
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        val statistikkStønadDTO = stønadsdata.get().values.find { it.brukerId == gammeltFnr.verdi }
+        statistikkStønadDTO?.let {
+            stønadsdata.get()[it.sakId] = it.copy(
+                brukerId = nyttFnr.verdi,
+            )
+        }
+    }
+
+    override fun hent(sakId: SakId): List<StatistikkStønadDTO> {
+        return stønadsdata.get()[sakId.toString()]?.let { listOf(it) } ?: emptyList()
     }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/SøknadFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/SøknadFakeRepo.kt
@@ -34,6 +34,17 @@ class SøknadFakeRepo : SøknadRepo {
         data.get()[søknad.id] = søknad
     }
 
+    override fun oppdaterFnr(gammeltFnr: Fnr, nyttFnr: Fnr) {
+        val soknad = data.get().values.find { it.fnr == gammeltFnr }
+        soknad?.let {
+            data.get()[it.id] = it.copy(
+                personopplysninger = it.personopplysninger.copy(
+                    fnr = nyttFnr,
+                ),
+            )
+        }
+    }
+
     fun hentForSakId(sakId: SakId): List<Søknad> {
         return data.get().filter { it.value.sakId == sakId }.values.toList()
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobbTest.kt
@@ -1,0 +1,273 @@
+package no.nav.tiltakspenger.saksbehandling.person.identhendelser.jobb
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.random
+import no.nav.tiltakspenger.libs.json.objectMapper
+import no.nav.tiltakspenger.libs.kafka.Producer
+import no.nav.tiltakspenger.libs.periodisering.zoneIdOslo
+import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.genererSaksstatistikkForRammevedtak
+import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.genererStønadsstatistikkForRammevedtak
+import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterIverksattFørstegangsbehandling
+import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterSakOgSøknad
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMigratedDb
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.Identtype
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.Personident
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseDto
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseKafkaProducer
+import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseDb
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class IdenthendelseJobbTest {
+    private val kafkaProducer = mockk<Producer<String, String>>()
+    private val identhendelseKafkaProducer = IdenthendelseKafkaProducer(kafkaProducer, "topic")
+
+    @BeforeEach
+    fun clearMockData() {
+        clearMocks(kafkaProducer)
+        coEvery {
+            kafkaProducer.produce(
+                any(),
+                any(),
+                any(),
+            )
+        } just Runs
+    }
+
+    @Test
+    fun `behandleIdenthendelser - hendelsen er ikke behandlet - oppdaterer i database og produserer til kafka`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakRepo = testDataHelper.sakRepo
+                val søknadRepo = testDataHelper.søknadRepo
+                val statistikkSakRepo = testDataHelper.statistikkSakRepo
+                val statistikkStønadRepo = testDataHelper.statistikkStønadRepo
+                val identhendelseJobb = IdenthendelseJobb(
+                    identhendelseRepository = identhendelseRepository,
+                    identhendelseKafkaProducer = identhendelseKafkaProducer,
+                    sakRepo = sakRepo,
+                    søknadRepo = søknadRepo,
+                    statistikkSakRepo = statistikkSakRepo,
+                    statistikkStønadRepo = statistikkStønadRepo,
+                )
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+
+                val sak = ObjectMother.nySak(fnr = gammeltFnr)
+                val deltakelseFom = LocalDate.now().minusMonths(3)
+                val deltakelsesTom = LocalDate.now().minusWeeks(2)
+                val (_, vedtak, _) = testDataHelper.persisterIverksattFørstegangsbehandling(
+                    sakId = sak.id,
+                    fnr = gammeltFnr,
+                    deltakelseFom = deltakelseFom,
+                    deltakelseTom = deltakelsesTom,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = gammeltFnr),
+                        søknadstiltak = ObjectMother.søknadstiltak(
+                            deltakelseFom = deltakelseFom,
+                            deltakelseTom = deltakelsesTom,
+                        ),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+                statistikkSakRepo.lagre(
+                    genererSaksstatistikkForRammevedtak(
+                        vedtak = vedtak,
+                        gjelderKode6 = false,
+                        versjon = "1",
+                        clock = Clock.system(zoneIdOslo),
+                    ),
+                )
+                statistikkStønadRepo.lagre(
+                    genererStønadsstatistikkForRammevedtak(
+                        vedtak,
+                    ),
+                )
+                val identhendelseDb = IdenthendelseDb(
+                    id = UUID.randomUUID(),
+                    gammeltFnr = gammeltFnr,
+                    nyttFnr = nyttFnr,
+                    sakId = sak.id,
+                    personidenter = listOf(
+                        Personident(nyttFnr.verdi, false, Identtype.FOLKEREGISTERIDENT),
+                        Personident(gammeltFnr.verdi, true, Identtype.FOLKEREGISTERIDENT),
+                    ),
+                    produsertHendelse = null,
+                    oppdatertDatabase = null,
+                )
+                identhendelseRepository.lagre(identhendelseDb)
+
+                identhendelseJobb.behandleIdenthendelser()
+
+                coVerify(exactly = 1) {
+                    kafkaProducer.produce(
+                        any(),
+                        identhendelseDb.id.toString(),
+                        objectMapper.writeValueAsString(IdenthendelseDto(gammeltFnr.verdi, nyttFnr.verdi)),
+                    )
+                }
+                val oppdatertIdenthendelseDb = identhendelseRepository.hent(identhendelseDb.id)
+                oppdatertIdenthendelseDb shouldNotBe null
+                oppdatertIdenthendelseDb?.produsertHendelse?.toLocalDate() shouldBe LocalDate.now()
+                oppdatertIdenthendelseDb?.oppdatertDatabase?.toLocalDate() shouldBe LocalDate.now()
+
+                sakRepo.hentForSakId(sak.id)?.fnr shouldBe nyttFnr
+                søknadRepo.hentSøknaderForFnr(gammeltFnr) shouldBe emptyList()
+                søknadRepo.hentSøknaderForFnr(nyttFnr).size shouldBe 1
+                statistikkSakRepo.hent(sak.id).first().fnr shouldBe nyttFnr.verdi
+                statistikkSakRepo.hent(sak.id).first().fnr shouldBe nyttFnr.verdi
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelser - hendelsen er produsert på kafka, ikke oppdatert i db - oppdaterer i database`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakRepo = testDataHelper.sakRepo
+                val søknadRepo = testDataHelper.søknadRepo
+                val statistikkSakRepo = testDataHelper.statistikkSakRepo
+                val statistikkStønadRepo = testDataHelper.statistikkStønadRepo
+                val identhendelseJobb = IdenthendelseJobb(
+                    identhendelseRepository = identhendelseRepository,
+                    identhendelseKafkaProducer = identhendelseKafkaProducer,
+                    sakRepo = sakRepo,
+                    søknadRepo = søknadRepo,
+                    statistikkSakRepo = statistikkSakRepo,
+                    statistikkStønadRepo = statistikkStønadRepo,
+                )
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+
+                val sak = ObjectMother.nySak(fnr = gammeltFnr)
+                val deltakelseFom = LocalDate.now().minusMonths(3)
+                val deltakelsesTom = LocalDate.now().minusWeeks(2)
+                val (_, vedtak, _) = testDataHelper.persisterIverksattFørstegangsbehandling(
+                    sakId = sak.id,
+                    fnr = gammeltFnr,
+                    deltakelseFom = deltakelseFom,
+                    deltakelseTom = deltakelsesTom,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = gammeltFnr),
+                        søknadstiltak = ObjectMother.søknadstiltak(
+                            deltakelseFom = deltakelseFom,
+                            deltakelseTom = deltakelsesTom,
+                        ),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+                statistikkSakRepo.lagre(
+                    genererSaksstatistikkForRammevedtak(
+                        vedtak = vedtak,
+                        gjelderKode6 = false,
+                        versjon = "1",
+                        clock = Clock.system(zoneIdOslo),
+                    ),
+                )
+                statistikkStønadRepo.lagre(
+                    genererStønadsstatistikkForRammevedtak(
+                        vedtak,
+                    ),
+                )
+                val identhendelseDb = IdenthendelseDb(
+                    id = UUID.randomUUID(),
+                    gammeltFnr = gammeltFnr,
+                    nyttFnr = nyttFnr,
+                    sakId = sak.id,
+                    personidenter = listOf(
+                        Personident(nyttFnr.verdi, false, Identtype.FOLKEREGISTERIDENT),
+                        Personident(gammeltFnr.verdi, true, Identtype.FOLKEREGISTERIDENT),
+                    ),
+                    produsertHendelse = LocalDateTime.now(),
+                    oppdatertDatabase = null,
+                )
+                identhendelseRepository.lagre(identhendelseDb)
+
+                identhendelseJobb.behandleIdenthendelser()
+
+                coVerify(exactly = 0) { kafkaProducer.produce(any(), any(), any()) }
+
+                val oppdatertIdenthendelseDb = identhendelseRepository.hent(identhendelseDb.id)
+                oppdatertIdenthendelseDb shouldNotBe null
+                oppdatertIdenthendelseDb?.produsertHendelse?.toLocalDate() shouldBe LocalDate.now()
+                oppdatertIdenthendelseDb?.oppdatertDatabase?.toLocalDate() shouldBe LocalDate.now()
+
+                sakRepo.hentForSakId(sak.id)?.fnr shouldBe nyttFnr
+                søknadRepo.hentSøknaderForFnr(gammeltFnr) shouldBe emptyList()
+                søknadRepo.hentSøknaderForFnr(nyttFnr).size shouldBe 1
+                statistikkSakRepo.hent(sak.id).first().fnr shouldBe nyttFnr.verdi
+                statistikkSakRepo.hent(sak.id).first().fnr shouldBe nyttFnr.verdi
+            }
+        }
+    }
+
+    @Test
+    fun `behandleIdenthendelser - hendelsen er ferdig behandlet - ignorerer`() {
+        withMigratedDb(runIsolated = true) { testDataHelper ->
+            runBlocking {
+                val identhendelseRepository = testDataHelper.identhendelseRepository
+                val sakRepo = testDataHelper.sakRepo
+                val søknadRepo = testDataHelper.søknadRepo
+                val statistikkSakRepo = testDataHelper.statistikkSakRepo
+                val statistikkStønadRepo = testDataHelper.statistikkStønadRepo
+                val identhendelseJobb = IdenthendelseJobb(
+                    identhendelseRepository = identhendelseRepository,
+                    identhendelseKafkaProducer = identhendelseKafkaProducer,
+                    sakRepo = sakRepo,
+                    søknadRepo = søknadRepo,
+                    statistikkSakRepo = statistikkSakRepo,
+                    statistikkStønadRepo = statistikkStønadRepo,
+                )
+                val gammeltFnr = Fnr.random()
+                val nyttFnr = Fnr.random()
+                val sak = ObjectMother.nySak(fnr = nyttFnr)
+                testDataHelper.persisterSakOgSøknad(
+                    fnr = nyttFnr,
+                    sak = sak,
+                    søknad = ObjectMother.nySøknad(
+                        personopplysninger = ObjectMother.personSøknad(fnr = nyttFnr),
+                        sakId = sak.id,
+                        saksnummer = sak.saksnummer,
+                    ),
+                )
+                val identhendelseDb = IdenthendelseDb(
+                    id = UUID.randomUUID(),
+                    gammeltFnr = gammeltFnr,
+                    nyttFnr = nyttFnr,
+                    sakId = sak.id,
+                    personidenter = listOf(
+                        Personident(nyttFnr.verdi, false, Identtype.FOLKEREGISTERIDENT),
+                        Personident(gammeltFnr.verdi, true, Identtype.FOLKEREGISTERIDENT),
+                    ),
+                    produsertHendelse = LocalDateTime.now(),
+                    oppdatertDatabase = LocalDateTime.now(),
+                )
+                identhendelseRepository.lagre(identhendelseDb)
+
+                identhendelseJobb.behandleIdenthendelser()
+
+                coVerify(exactly = 0) { kafkaProducer.produce(any(), any(), any()) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hvis det er endring på fnr på en av våre brukere så skriver vi endringen på intern kafkatopic slik at vi får propagert endringen videre ut i verdikjeden vår. Deretter oppdaterer vi i saksbehandling-api-databasen. 

Gjorde også en endring slik at vi ikke lagrer identhendelser i det hele tatt hvis en av endringene vil medføre at vi kan få flere saker pr fnr (sånn koden var ville vi ha lagret den første endringen, og dermed oppdatert i alle appene våre, og det er ikke sikkert at ville vært riktig). 

https://trello.com/c/Ck4Sc5nT/1430-hvis-bruker-som-finnes-i-v%C3%A5rt-system-endrer-fnr-s%C3%A5-skal-vi-oppdatere-alle-steder-der-vi-har-lagret-fnr