### PR TITLE
1446 må returnere id for søknadstiltaket for lettere matching i frontend

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/route/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/søknad/infra/route/SøknadDTO.kt
@@ -36,6 +36,7 @@ internal data class SøknadDTO(
     val visVedlegg: Boolean,
 ) {
     data class TiltaksdeltagelseFraSøknadDTO(
+        val id: String,
         val fraOgMed: String?,
         val tilOgMed: String?,
         val typeKode: String,
@@ -110,6 +111,7 @@ fun PeriodeSpm.toPeriodeDTO(): PeriodeDTO? {
 
 internal fun Søknadstiltak.toDTO(): SøknadDTO.TiltaksdeltagelseFraSøknadDTO {
     return SøknadDTO.TiltaksdeltagelseFraSøknadDTO(
+        id = id,
         fraOgMed = this.deltakelseFom.toString(),
         tilOgMed = this.deltakelseTom.toString(),
         typeKode = this.typeKode,


### PR DESCRIPTION
https://trello.com/c/1IB0frWG/1446-n%C3%A5r-bruker-har-flere-tiltak-b%C3%B8r-den-forh%C3%A5ndsutfylte-innvilgelsesperioden-v%C3%A6re-perioden-for-det-tiltaket-man-har-s%C3%B8kt-for