### PR TITLE
Ferdigstill rekkefolge

### DIFF
--- a/.github/workflows/.test-and-build.yml
+++ b/.github/workflows/.test-and-build.yml
@@ -12,8 +12,6 @@ on:
         description: "Docker image"
         value: ${{ jobs.build.outputs.IMAGE }}
     secrets:
-      NAIS_WORKLOAD_IDENTITY_PROVIDER:
-        required: true
       SLACK_VARSEL_WEBHOOK_URL:
         required: true
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,6 @@ jobs:
       contents: read
       id-token: write
     secrets:
-      NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
       SLACK_VARSEL_WEBHOOK_URL: ${{ secrets.SLACK_VARSEL_WEBHOOK_URL }}
 
   deploy:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,7 +15,6 @@ jobs:
       contents: read
       id-token: write
     secrets:
-      NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
       SLACK_VARSEL_WEBHOOK_URL: ${{ secrets.SLACK_VARSEL_WEBHOOK_URL }}
 
   deploy-dev:

--- a/.github/workflows/test-and-build-on-push.yml
+++ b/.github/workflows/test-and-build-on-push.yml
@@ -16,5 +16,4 @@ jobs:
     with:
       buildImage: false
     secrets:
-      NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
       SLACK_VARSEL_WEBHOOK_URL: ${{ secrets.SLACK_VARSEL_WEBHOOK_URL }}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/behandling/IverksettBehandlingService.kt
@@ -105,15 +105,6 @@ class IverksettBehandlingService(
                 vedtak,
             )
 
-        Either.catch {
-            behandling.oppgaveId?.let { id ->
-                logger.info { "Ferdigstiller oppgave med id $id for behandling med behandlingsId $behandlingId" }
-                oppgaveGateway.ferdigstillOppgave(id)
-            }
-        }.onLeft {
-            return KanIkkeIverksetteBehandling.KunneIkkeOppretteOppgave.left()
-        }
-
         when (behandling.behandlingstype) {
             Behandlingstype.FØRSTEGANGSBEHANDLING -> oppdatertSak.iverksettFørstegangsbehandling(
                 vedtak = vedtak,
@@ -126,6 +117,15 @@ class IverksettBehandlingService(
                 sakStatistikk = sakStatistikk,
                 stønadStatistikk = stønadStatistikk,
             )
+        }
+
+        Either.catch {
+            behandling.oppgaveId?.let { id ->
+                logger.info { "Ferdigstiller oppgave med id $id for behandling med behandlingsId $behandlingId" }
+                oppgaveGateway.ferdigstillOppgave(id)
+            }
+        }.onLeft {
+            return KanIkkeIverksetteBehandling.KunneIkkeOppretteOppgave.left()
         }
 
         return iverksattBehandling.right()


### PR DESCRIPTION
Flytter ferdigstillingen av oppgave til etter vi er ferdig med lagringen slik at hvis ferdigstilling feiler så slipper vi at dataene våre er i usynk, da er det kun ferdigstillingen som mangler. 