### PR TITLE
Overta meldekortbehandling

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
@@ -56,6 +56,7 @@ fun Route.routes(
         tokenService = applicationContext.tokenService,
         mottaBrukerutfyltMeldekortService = applicationContext.mottaBrukerutfyltMeldekortService,
         underkjennMeldekortBehandlingService = applicationContext.meldekortContext.underkjennMeldekortBehandlingService,
+        overtaMeldekortBehandlingService = applicationContext.meldekortContext.overtaMeldekortBehandlingService,
         clock = applicationContext.clock,
     )
     mottaSøknadRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlet.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlet.kt
@@ -15,9 +15,9 @@ import no.nav.tiltakspenger.saksbehandling.felles.AttesteringId
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringsstatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BEHANDLING
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
@@ -72,7 +72,7 @@ data class MeldekortBehandlet(
             "Til og med dato for beregningsperioden må være nyere eller lik meldeperioden"
         }
         when (status) {
-            IKKE_BEHANDLET -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status IKKE_BEHANDLET")
+            UNDER_BEHANDLING -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status UNDER_BEHANDLING")
             KLAR_TIL_BESLUTNING -> {
                 require(iverksattTidspunkt == null)
                 // Kommentar jah: Når vi legger til underkjenn, bør vi også legge til et atteserings objekt som for Behandling. beslutter vil da flyttes dit.
@@ -175,7 +175,7 @@ data class MeldekortBehandlet(
         saksbehandler: Saksbehandler,
     ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
         return when (this.status) {
-            IKKE_BEHANDLET -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status IKKE_BEHANDLET")
+            UNDER_BEHANDLING -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status UNDER_BEHANDLING")
             KLAR_TIL_BESLUTNING -> KunneIkkeOvertaMeldekortBehandling.BehandlingenMåVæreUnderBeslutningForÅOverta.left()
             GODKJENT,
             IKKE_RETT_TIL_TILTAKSPENGER,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlet.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlet.kt
@@ -18,6 +18,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingS
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
 import java.time.Clock
@@ -166,6 +167,20 @@ data class MeldekortBehandlet(
             sendtTilBeslutning = sendtTilBeslutning,
             dager = dager,
         ).right()
+    }
+
+    // TODO: Vi må innføre en ny status UNDER_BESLUTNING der beslutter er tildelt for at det skal gi mening å overta
+    // behandlingen som er til beslutning. Kommer i egen endring.
+    override fun overta(
+        saksbehandler: Saksbehandler,
+    ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
+        return when (this.status) {
+            IKKE_BEHANDLET -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status IKKE_BEHANDLET")
+            KLAR_TIL_BESLUTNING -> KunneIkkeOvertaMeldekortBehandling.BehandlingenMåVæreUnderBeslutningForÅOverta.left()
+            GODKJENT,
+            IKKE_RETT_TIL_TILTAKSPENGER,
+            -> KunneIkkeOvertaMeldekortBehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett.left()
+        }
     }
 
     fun tilUnderBehandling(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -13,9 +13,9 @@ import no.nav.tiltakspenger.libs.periodisering.Periodisering
 import no.nav.tiltakspenger.libs.tiltak.TiltakstypeSomGirRett
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BEHANDLING
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
@@ -58,7 +58,7 @@ sealed interface MeldekortBehandling {
     /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den vil bli erstattet med AVBRUTT senere. */
     val erAvsluttet
         get() = when (status) {
-            IKKE_BEHANDLET, KLAR_TIL_BESLUTNING -> false
+            UNDER_BEHANDLING, KLAR_TIL_BESLUTNING -> false
             GODKJENT, IKKE_RETT_TIL_TILTAKSPENGER -> true
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -16,6 +16,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingS
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
 import java.time.Clock
@@ -101,4 +102,8 @@ sealed interface MeldekortBehandling {
         beslutter: Saksbehandler,
         clock: Clock,
     ): Either<KunneIkkeUnderkjenneMeldekortBehandling, MeldekortBehandling>
+
+    fun overta(
+        saksbehandler: Saksbehandler,
+    ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling>
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.saksbehandling.meldekort.domene
 
 enum class MeldekortBehandlingStatus {
-    IKKE_BEHANDLET,
+    UNDER_BEHANDLING,
     KLAR_TIL_BESLUTNING,
     GODKJENT,
     IKKE_RETT_TIL_TILTAKSPENGER,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -149,8 +149,8 @@ data class MeldekortUnderBehandling(
             }
             KLAR_TIL_BESLUTNING,
             GODKJENT,
-            -> throw IllegalStateException("Meldekort under behandling kan ikke ha status ${this.status}")
-            IKKE_RETT_TIL_TILTAKSPENGER -> KunneIkkeOvertaMeldekortBehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett.left()
+            IKKE_RETT_TIL_TILTAKSPENGER,
+            -> throw IllegalStateException("Kan ikke overta meldekortbehandling med status ${this.status}")
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -12,9 +12,11 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
@@ -134,6 +136,22 @@ data class MeldekortUnderBehandling(
         clock: Clock,
     ): Either<KunneIkkeUnderkjenneMeldekortBehandling, MeldekortBehandling> {
         return KunneIkkeUnderkjenneMeldekortBehandling.BehandlingenErIkkeKlarTilBeslutning.left()
+    }
+
+    override fun overta(
+        saksbehandler: Saksbehandler,
+    ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
+        return when (this.status) {
+            IKKE_BEHANDLET -> {
+                this.copy(
+                    saksbehandler = saksbehandler.navIdent,
+                ).right()
+            }
+            KLAR_TIL_BESLUTNING,
+            GODKJENT,
+            -> throw IllegalStateException("Meldekort under behandling kan ikke ha status ${this.status}")
+            IKKE_RETT_TIL_TILTAKSPENGER -> KunneIkkeOvertaMeldekortBehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett.left()
+        }
     }
 
     init {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -13,9 +13,9 @@ import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
-import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_BEHANDLET
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BEHANDLING
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -45,7 +45,7 @@ data class MeldekortUnderBehandling(
     override val iverksattTidspunkt = null
 
     override val status =
-        if (ikkeRettTilTiltakspengerTidspunkt == null) IKKE_BEHANDLET else IKKE_RETT_TIL_TILTAKSPENGER
+        if (ikkeRettTilTiltakspengerTidspunkt == null) UNDER_BEHANDLING else IKKE_RETT_TIL_TILTAKSPENGER
 
     override val beslutter = null
 
@@ -142,7 +142,7 @@ data class MeldekortUnderBehandling(
         saksbehandler: Saksbehandler,
     ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
         return when (this.status) {
-            IKKE_BEHANDLET -> {
+            UNDER_BEHANDLING -> {
                 this.copy(
                     saksbehandler = saksbehandler.navIdent,
                 ).right()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
@@ -283,7 +283,7 @@ class MeldekortBehandlingPostgresRepo(
                     )
                 }
                 // TODO jah: Her blander vi sammen behandlingsstatus og om man har rett/ikke-rett. Det er mulig at man har startet en meldekortbehandling også endres statusen til IKKE_RETT_TIL_TILTAKSPENGER. Da vil behandlingen sånn som koden er nå implisitt avsluttes. Det kan hende vi bør endre dette når vi skiller grunnlag, innsending og behandling.
-                MeldekortBehandlingStatus.IKKE_BEHANDLET, MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> {
+                MeldekortBehandlingStatus.UNDER_BEHANDLING, MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> {
                     val beregning = row.stringOrNull("beregninger")?.tilBeregninger(id)?.let {
                         MeldekortBeregning(it)
                     }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
@@ -16,7 +16,7 @@ private enum class MeldekortBehandlingStatusDb {
 
 fun String.toMeldekortBehandlingStatus(): MeldekortBehandlingStatus =
     when (MeldekortBehandlingStatusDb.valueOf(this)) {
-        MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING -> MeldekortBehandlingStatus.IKKE_BEHANDLET
+        MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING -> MeldekortBehandlingStatus.UNDER_BEHANDLING
         MeldekortBehandlingStatusDb.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
         MeldekortBehandlingStatusDb.GODKJENT -> MeldekortBehandlingStatus.GODKJENT
         MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
@@ -24,7 +24,7 @@ fun String.toMeldekortBehandlingStatus(): MeldekortBehandlingStatus =
 
 fun MeldekortBehandlingStatus.toDb(): String =
     when (this) {
-        MeldekortBehandlingStatus.IKKE_BEHANDLET -> MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING
+        MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING
         MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatusDb.KLAR_TIL_BESLUTNING
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDb.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
@@ -10,6 +10,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.service.MottaBrukerutfyltMe
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.UnderkjennMeldekortBehandlingService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingService
 import java.time.Clock
 
 fun Route.meldekortRoutes(
@@ -21,6 +22,7 @@ fun Route.meldekortRoutes(
     tokenService: TokenService,
     mottaBrukerutfyltMeldekortService: MottaBrukerutfyltMeldekortService,
     underkjennMeldekortBehandlingService: UnderkjennMeldekortBehandlingService,
+    overtaMeldekortBehandlingService: OvertaMeldekortBehandlingService,
     clock: Clock,
 ) {
     hentMeldekortRoute(sakService, auditService, tokenService, clock)
@@ -28,6 +30,7 @@ fun Route.meldekortRoutes(
     sendMeldekortTilBeslutterRoute(oppdaterMeldekortService, auditService, tokenService, clock)
     oppdaterMeldekortBehandlingRoute(oppdaterMeldekortService, auditService, tokenService, clock)
     opprettMeldekortBehandlingRoute(opprettMeldekortBehandlingService, auditService, tokenService, clock)
+    overtaMeldekortBehandlingRoute(tokenService, overtaMeldekortBehandlingService, auditService)
     mottaMeldekortRoutes(mottaBrukerutfyltMeldekortService)
     underkjennMeldekortBehandlingRoute(underkjennMeldekortBehandlingService, auditService, tokenService)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRoute.kt
@@ -1,0 +1,96 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.patch
+import no.nav.tiltakspenger.libs.auth.core.TokenService
+import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.ErrorJson
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
+import no.nav.tiltakspenger.saksbehandling.infra.repo.correlationId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withBody
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMeldekortId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withSakId
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.UtbetalingsstatusDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.toMeldekortBehandlingDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingCommand
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingService
+
+internal const val OVERTA_MELDEKORTBEHANDLING_PATH = "/sak/{sakId}/meldekort/{meldekortId}/overta"
+
+data class OvertaBehandlingBody(
+    val overtarFra: String,
+)
+
+fun Route.overtaMeldekortBehandlingRoute(
+    tokenService: TokenService,
+    overtaMeldekortBehandlingService: OvertaMeldekortBehandlingService,
+    auditService: AuditService,
+) {
+    val logger = KotlinLogging.logger {}
+    patch(OVERTA_MELDEKORTBEHANDLING_PATH) {
+        logger.debug { "Mottatt post-request på '$OVERTA_MELDEKORTBEHANDLING_PATH' - Tar over meldekortbehandling" }
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withSakId { sakId ->
+                call.withMeldekortId { meldekortId ->
+                    call.withBody<OvertaBehandlingBody> { body ->
+                        val correlationId = call.correlationId()
+                        overtaMeldekortBehandlingService.overta(
+                            OvertaMeldekortBehandlingCommand(
+                                sakId = sakId,
+                                meldekortId = meldekortId,
+                                saksbehandler = saksbehandler,
+                                correlationId = correlationId,
+                                overtarFra = body.overtarFra,
+                            ),
+                        ).fold(
+                            {
+                                val (status, error) = it.tilStatusOgErrorJson()
+                                call.respond(status, error)
+                            },
+                            {
+                                auditService.logMedMeldekortId(
+                                    meldekortId = meldekortId,
+                                    navIdent = saksbehandler.navIdent,
+                                    action = AuditLogEvent.Action.UPDATE,
+                                    contextMessage = "Overtar meldekortbehandlingen",
+                                    correlationId = correlationId,
+                                )
+
+                                call.respond(HttpStatusCode.OK, it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.IKKE_GODKJENT))
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun KunneIkkeOvertaMeldekortBehandling.tilStatusOgErrorJson(): Pair<HttpStatusCode, ErrorJson> {
+    return when (this) {
+        KunneIkkeOvertaMeldekortBehandling.BehandlingenKanIkkeVæreGodkjentEllerIkkeRett -> HttpStatusCode.BadRequest to ErrorJson(
+            "Behandlingen kan ikke være godkjent eller ikke rett på tiltakspenger",
+            "behandlingen_kan_ikke_være_godkjent_eller_ikke_rett",
+        )
+
+        KunneIkkeOvertaMeldekortBehandling.BehandlingenErIkkeKnyttetTilEnBeslutterForÅOverta -> HttpStatusCode.BadRequest to ErrorJson(
+            "Behandlingen har ikke en eksisterende beslutter å overta fra",
+            "behandlingen_har_ikke_eksisterende_beslutter",
+        )
+
+        KunneIkkeOvertaMeldekortBehandling.SaksbehandlerOgBeslutterKanIkkeVæreDenSamme -> HttpStatusCode.BadRequest to ErrorJson(
+            "Saksbehandler og beslutter kan ikke være den samme på samme behandling",
+            "saksbehandler_og_beslutter_kan_ikke_vær_den_samme",
+        )
+
+        KunneIkkeOvertaMeldekortBehandling.BehandlingenMåVæreUnderBeslutningForÅOverta -> HttpStatusCode.BadRequest to ErrorJson(
+            "Behandlingen må være under beslutning for å overta",
+            "behandling_må_være_under_beslutning",
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
@@ -12,7 +12,7 @@ enum class MeldekortBehandlingStatusDTO {
 
 fun MeldekortBehandling.toStatusDTO(): MeldekortBehandlingStatusDTO {
     return when (this.status) {
-        MeldekortBehandlingStatus.IKKE_BEHANDLET -> MeldekortBehandlingStatusDTO.KLAR_TIL_UTFYLLING
+        MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldekortBehandlingStatusDTO.KLAR_TIL_UTFYLLING
         MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatusDTO.KLAR_TIL_BESLUTNING
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDTO.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
@@ -20,7 +20,7 @@ fun Sak.toMeldeperiodeKjedeStatusDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock)
             MeldekortBehandlingStatus.GODKJENT -> MeldeperiodeKjedeStatusDTO.GODKJENT
             MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldeperiodeKjedeStatusDTO.KLAR_TIL_BESLUTNING
             MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldeperiodeKjedeStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER
-            MeldekortBehandlingStatus.IKKE_BEHANDLET -> MeldeperiodeKjedeStatusDTO.UNDER_BEHANDLING
+            MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldeperiodeKjedeStatusDTO.UNDER_BEHANDLING
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
@@ -24,6 +24,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppgaveMeldekortSer
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.SendMeldeperiodeTilBrukerService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.UnderkjennMeldekortBehandlingService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
 import no.nav.tiltakspenger.saksbehandling.utbetaling.ports.UtbetalingsvedtakRepo
 import java.time.Clock
@@ -121,6 +122,13 @@ open class MeldekortContext(
             meldekortBehandlingRepo = meldekortBehandlingRepo,
             tilgangsstyringService = tilgangsstyringService,
             clock = clock,
+        )
+    }
+
+    val overtaMeldekortBehandlingService by lazy {
+        OvertaMeldekortBehandlingService(
+            tilgangsstyringService = tilgangsstyringService,
+            meldekortBehandlingRepo = meldekortBehandlingRepo,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.saksbehandling.meldekort.ports
 
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
@@ -31,4 +32,11 @@ interface MeldekortBehandlingRepo {
         meldekortId: MeldekortId,
         sessionContext: SessionContext? = null,
     ): MeldekortBehandling?
+
+    fun overtaSaksbehandler(
+        meldekortId: MeldekortId,
+        nySaksbehandler: Saksbehandler,
+        nåværendeSaksbehandler: String,
+        sessionContext: SessionContext? = null,
+    ): Boolean
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/KunneIkkeOvertaMeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/KunneIkkeOvertaMeldekortBehandling.kt
@@ -1,0 +1,8 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.service.overta
+
+sealed interface KunneIkkeOvertaMeldekortBehandling {
+    data object BehandlingenKanIkkeVæreGodkjentEllerIkkeRett : KunneIkkeOvertaMeldekortBehandling
+    data object BehandlingenErIkkeKnyttetTilEnBeslutterForÅOverta : KunneIkkeOvertaMeldekortBehandling
+    data object BehandlingenMåVæreUnderBeslutningForÅOverta : KunneIkkeOvertaMeldekortBehandling
+    data object SaksbehandlerOgBeslutterKanIkkeVæreDenSamme : KunneIkkeOvertaMeldekortBehandling
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingCommand.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingCommand.kt
@@ -1,0 +1,15 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.service.overta
+
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.saksbehandling.felles.ServiceCommand
+
+data class OvertaMeldekortBehandlingCommand(
+    val sakId: SakId,
+    val meldekortId: MeldekortId,
+    val overtarFra: String,
+    override val saksbehandler: Saksbehandler,
+    override val correlationId: CorrelationId,
+) : ServiceCommand

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
@@ -1,0 +1,43 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.service.overta
+
+import arrow.core.Either
+import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
+import no.nav.tiltakspenger.saksbehandling.felles.exceptions.TilgangException
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
+
+class OvertaMeldekortBehandlingService(
+    private val tilgangsstyringService: TilgangsstyringService,
+    private val meldekortBehandlingRepo: MeldekortBehandlingRepo,
+) {
+    suspend fun overta(command: OvertaMeldekortBehandlingCommand): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
+        val meldekortBehandling = meldekortBehandlingRepo.hent(command.meldekortId)
+            ?: throw IllegalStateException("Fant ikke meldekortBehandling for id ${command.meldekortId}")
+        tilgangsstyringService.harTilgangTilPerson(
+            meldekortBehandling.fnr,
+            command.saksbehandler.roller,
+            command.correlationId,
+        )
+            .onLeft {
+                throw TilgangException("Feil ved tilgangssjekk til person ved overtakelse av meldekortbehandling. Feilen var $it")
+            }.onRight {
+                if (!it) throw TilgangException("Saksbehandler ${command.saksbehandler.navIdent} har ikke tilgang til person")
+            }
+
+        return meldekortBehandling.overta(command.saksbehandler).onRight {
+            when (it.status) {
+                MeldekortBehandlingStatus.IKKE_BEHANDLET -> meldekortBehandlingRepo.overtaSaksbehandler(
+                    it.id,
+                    command.saksbehandler,
+                    command.overtarFra,
+                )
+
+                MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+                MeldekortBehandlingStatus.GODKJENT,
+                MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
+                -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne overta")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
@@ -27,7 +27,7 @@ class OvertaMeldekortBehandlingService(
 
         return meldekortBehandling.overta(command.saksbehandler).onRight {
             when (it.status) {
-                MeldekortBehandlingStatus.IKKE_BEHANDLET -> meldekortBehandlingRepo.overtaSaksbehandler(
+                MeldekortBehandlingStatus.UNDER_BEHANDLING -> meldekortBehandlingRepo.overtaSaksbehandler(
                     it.id,
                     command.saksbehandler,
                     command.overtarFra,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRouteTest.kt
@@ -52,7 +52,7 @@ class OvertaMeldekortBehandlingRouteTest {
                     JSONObject(it).getString("saksbehandler") shouldBe "123"
                     val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
                     oppdatertMeldekortbehandling shouldNotBe null
-                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.IKKE_BEHANDLET
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.UNDER_BEHANDLING
                     oppdatertMeldekortbehandling?.saksbehandler shouldBe "123"
                 }
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/OvertaMeldekortBehandlingRouteTest.kt
@@ -1,0 +1,90 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.util.url
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.test.common.defaultRequest
+import no.nav.tiltakspenger.saksbehandling.common.TestApplicationContext
+import no.nav.tiltakspenger.saksbehandling.infra.route.routes
+import no.nav.tiltakspenger.saksbehandling.infra.setup.jacksonSerialization
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.iverksett
+import org.json.JSONObject
+import org.junit.jupiter.api.Test
+
+class OvertaMeldekortBehandlingRouteTest {
+    @Test
+    fun `saksbehandler kan overta meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val saksbehandlerIdent = "Z12345"
+                val meldekortBehandling = ObjectMother.meldekortUnderBehandling(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    saksbehandler = saksbehandlerIdent,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                overtaMeldekortBehandling(tac, meldekortBehandling.sakId, meldekortBehandling.id, saksbehandlerIdent, ObjectMother.saksbehandler123()).also {
+                    JSONObject(it).getString("saksbehandler") shouldBe "123"
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.IKKE_BEHANDLET
+                    oppdatertMeldekortbehandling?.saksbehandler shouldBe "123"
+                }
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.overtaMeldekortBehandling(
+        tac: TestApplicationContext,
+        sakId: SakId,
+        meldekortId: MeldekortId,
+        overtarFra: String,
+        saksbehandler: Saksbehandler = ObjectMother.saksbehandler(),
+    ): String {
+        defaultRequest(
+            HttpMethod.Patch,
+            url {
+                protocol = URLProtocol.HTTPS
+                path("/sak/$sakId/meldekort/$meldekortId/overta")
+            },
+            jwt = tac.jwtGenerator.createJwtForSaksbehandler(
+                saksbehandler = saksbehandler,
+            ),
+        ) {
+            this.setBody("""{"overtarFra":"$overtarFra"}""")
+        }.apply {
+            val bodyAsText = this.bodyAsText()
+            withClue(
+                "Response details:\n" + "Status: ${this.status}\n" + "Content-Type: ${this.contentType()}\n" + "Body: $bodyAsText\n",
+            ) {
+                status shouldBe HttpStatusCode.OK
+            }
+            return bodyAsText
+        }
+    }
+}


### PR DESCRIPTION
Saksbehandler skal kunne overta en meldekortbehandling fra en annen saksbehandler. Har også renamet statusen meldekortbehandlingen får når den opprettes så det er tydelig at den da er under behandling (den opprettes av saksbehandler). 

https://trello.com/c/iYXkiirR/1458-en-p%C3%A5startet-manuell-meldekortbehandling-m%C3%A5-kunne-overtas-av-en-annen-saksbehandler