### PR TITLE
Meldekort tildel beslutter

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
@@ -57,6 +57,7 @@ fun Route.routes(
         mottaBrukerutfyltMeldekortService = applicationContext.mottaBrukerutfyltMeldekortService,
         underkjennMeldekortBehandlingService = applicationContext.meldekortContext.underkjennMeldekortBehandlingService,
         overtaMeldekortBehandlingService = applicationContext.meldekortContext.overtaMeldekortBehandlingService,
+        taMeldekortBehandlingService = applicationContext.meldekortContext.taMeldekortBehandlingService,
         clock = applicationContext.clock,
     )
     mottaSøknadRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KunneIkkeUnderkjenneMeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KunneIkkeUnderkjenneMeldekortBehandling.kt
@@ -2,7 +2,7 @@ package no.nav.tiltakspenger.saksbehandling.meldekort.domene
 
 sealed interface KunneIkkeUnderkjenneMeldekortBehandling {
     data object BegrunnelseMåVæreUtfylt : KunneIkkeUnderkjenneMeldekortBehandling
-    data object BehandlingenErIkkeKlarTilBeslutning : KunneIkkeUnderkjenneMeldekortBehandling
+    data object BehandlingenErIkkeUnderBeslutning : KunneIkkeUnderkjenneMeldekortBehandling
     data object SaksbehandlerKanIkkeUnderkjenneSinEgenBehandling : KunneIkkeUnderkjenneMeldekortBehandling
     data object BehandlingenErAlleredeBesluttet : KunneIkkeUnderkjenneMeldekortBehandling
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
@@ -58,6 +58,10 @@ data class MeldekortBehandletAutomatisk(
     override fun overta(saksbehandler: Saksbehandler): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
         return KunneIkkeOvertaMeldekortBehandling.KanIkkeOvertaAutomatiskBehandling.left()
     }
+
+    override fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling {
+        throw IllegalStateException("Kan ikke tildele automatisk behandlet meldekort")
+    }
 }
 
 fun Sak.opprettAutomatiskMeldekortBehandling(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -16,6 +16,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingS
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -62,7 +63,7 @@ sealed interface MeldekortBehandling {
     /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den vil bli erstattet med AVBRUTT senere. */
     val erAvsluttet
         get() = when (status) {
-            UNDER_BEHANDLING, KLAR_TIL_BESLUTNING -> false
+            UNDER_BEHANDLING, KLAR_TIL_BESLUTNING, UNDER_BESLUTNING -> false
             GODKJENT, AUTOMATISK_BEHANDLET, IKKE_RETT_TIL_TILTAKSPENGER -> true
         }
 
@@ -103,6 +104,8 @@ sealed interface MeldekortBehandling {
     }
 
     fun overta(saksbehandler: Saksbehandler): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling>
+
+    fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling
 
     sealed interface Behandlet : MeldekortBehandling {
         override val beregning: MeldekortBeregning

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
@@ -3,6 +3,7 @@ package no.nav.tiltakspenger.saksbehandling.meldekort.domene
 enum class MeldekortBehandlingStatus {
     UNDER_BEHANDLING,
     KLAR_TIL_BESLUTNING,
+    UNDER_BESLUTNING,
     GODKJENT,
     AUTOMATISK_BEHANDLET,
     IKKE_RETT_TIL_TILTAKSPENGER,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -16,6 +16,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingS
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BEHANDLING
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.UNDER_BESLUTNING
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
@@ -141,11 +142,16 @@ data class MeldekortUnderBehandling(
             }
 
             KLAR_TIL_BESLUTNING,
+            UNDER_BESLUTNING,
             GODKJENT,
             IKKE_RETT_TIL_TILTAKSPENGER,
             AUTOMATISK_BEHANDLET,
             -> throw IllegalStateException("Kan ikke overta meldekortbehandling med status ${this.status}")
         }
+    }
+
+    override fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling {
+        throw IllegalStateException("Kan ikke tildele meldekortbehandling som ikke er klar til beslutning")
     }
 
     init {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
@@ -10,6 +10,7 @@ private enum class MeldekortBehandlingStatusDb {
     // TODO post-mvp: Rename denne til IKKE_UTFYLT og lag et migreringsskript for det.
     KLAR_TIL_UTFYLLING,
     KLAR_TIL_BESLUTNING,
+    UNDER_BESLUTNING,
     GODKJENT,
     IKKE_RETT_TIL_TILTAKSPENGER,
     AUTOMATISK_BEHANDLET,
@@ -19,6 +20,7 @@ fun String.toMeldekortBehandlingStatus(): MeldekortBehandlingStatus =
     when (MeldekortBehandlingStatusDb.valueOf(this)) {
         MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING -> MeldekortBehandlingStatus.UNDER_BEHANDLING
         MeldekortBehandlingStatusDb.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+        MeldekortBehandlingStatusDb.UNDER_BESLUTNING -> MeldekortBehandlingStatus.UNDER_BESLUTNING
         MeldekortBehandlingStatusDb.GODKJENT -> MeldekortBehandlingStatus.GODKJENT
         MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatusDb.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET
@@ -28,6 +30,7 @@ fun MeldekortBehandlingStatus.toDb(): String =
     when (this) {
         MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldekortBehandlingStatusDb.KLAR_TIL_UTFYLLING
         MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatusDb.KLAR_TIL_BESLUTNING
+        MeldekortBehandlingStatus.UNDER_BESLUTNING -> MeldekortBehandlingStatusDb.UNDER_BESLUTNING
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDb.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatusDb.AUTOMATISK_BEHANDLET

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.service.IverksettMeldekortS
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.MottaBrukerutfyltMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.TaMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.UnderkjennMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingService
 import java.time.Clock
@@ -23,6 +24,7 @@ fun Route.meldekortRoutes(
     mottaBrukerutfyltMeldekortService: MottaBrukerutfyltMeldekortService,
     underkjennMeldekortBehandlingService: UnderkjennMeldekortBehandlingService,
     overtaMeldekortBehandlingService: OvertaMeldekortBehandlingService,
+    taMeldekortBehandlingService: TaMeldekortBehandlingService,
     clock: Clock,
 ) {
     hentMeldekortRoute(sakService, auditService, tokenService, clock)
@@ -32,5 +34,6 @@ fun Route.meldekortRoutes(
     opprettMeldekortBehandlingRoute(opprettMeldekortBehandlingService, auditService, tokenService, clock)
     overtaMeldekortBehandlingRoute(tokenService, overtaMeldekortBehandlingService, auditService)
     mottaMeldekortRoutes(mottaBrukerutfyltMeldekortService)
+    taMeldekortBehandlingRoute(tokenService, auditService, taMeldekortBehandlingService)
     underkjennMeldekortBehandlingRoute(underkjennMeldekortBehandlingService, auditService, tokenService)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRoute.kt
@@ -1,0 +1,51 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.tiltakspenger.libs.auth.core.TokenService
+import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
+import no.nav.tiltakspenger.saksbehandling.infra.repo.Standardfeil.måVæreSaksbehandlerEllerBeslutter
+import no.nav.tiltakspenger.saksbehandling.infra.repo.correlationId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMeldekortId
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.UtbetalingsstatusDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.toMeldekortBehandlingDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.TaMeldekortBehandlingService
+
+private const val TA_MELDEKORTBEHANDLING_PATH = "/sak/{sakId}/meldekort/{meldekortId}/ta"
+
+fun Route.taMeldekortBehandlingRoute(
+    tokenService: TokenService,
+    auditService: AuditService,
+    taMeldekortBehandlingService: TaMeldekortBehandlingService,
+) {
+    val logger = KotlinLogging.logger {}
+    post(TA_MELDEKORTBEHANDLING_PATH) {
+        logger.debug { "Mottatt post-request på '$TA_MELDEKORTBEHANDLING_PATH' - Knytter beslutter til meldekortbehandlingen." }
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withMeldekortId { meldekortId ->
+                val correlationId = call.correlationId()
+
+                taMeldekortBehandlingService.taMeldekortBehandling(meldekortId, saksbehandler, correlationId = correlationId).fold(
+                    { call.respond403Forbidden(måVæreSaksbehandlerEllerBeslutter()) },
+                    {
+                        auditService.logMedMeldekortId(
+                            meldekortId = meldekortId,
+                            navIdent = saksbehandler.navIdent,
+                            action = AuditLogEvent.Action.UPDATE,
+                            contextMessage = "Beslutter tar meldekortbehandlingen",
+                            correlationId = correlationId,
+                        )
+
+                        call.respond(status = HttpStatusCode.OK, it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.IKKE_GODKJENT))
+                    },
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/UnderkjennMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/UnderkjennMeldekortBehandlingRoute.kt
@@ -79,8 +79,8 @@ internal fun KunneIkkeUnderkjenneMeldekortBehandling.toErrorJson(): Pair<HttpSta
         "behandlingen_er_besluttet",
     )
 
-    KunneIkkeUnderkjenneMeldekortBehandling.BehandlingenErIkkeKlarTilBeslutning -> HttpStatusCode.BadRequest to ErrorJson(
-        "Behandlingen er ikke klar til beslutning",
+    KunneIkkeUnderkjenneMeldekortBehandling.BehandlingenErIkkeUnderBeslutning -> HttpStatusCode.BadRequest to ErrorJson(
+        "Behandlingen er ikke under beslutning",
         "behandlingen_er_ikke_klar_til_beslutning",
     )
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
@@ -6,6 +6,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingS
 enum class MeldekortBehandlingStatusDTO {
     KLAR_TIL_UTFYLLING,
     KLAR_TIL_BESLUTNING,
+    UNDER_BESLUTNING,
     GODKJENT,
     AUTOMATISK_BEHANDLET,
     IKKE_RETT_TIL_TILTAKSPENGER,
@@ -15,6 +16,7 @@ fun MeldekortBehandling.toStatusDTO(): MeldekortBehandlingStatusDTO {
     return when (this.status) {
         MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldekortBehandlingStatusDTO.KLAR_TIL_UTFYLLING
         MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldekortBehandlingStatusDTO.KLAR_TIL_BESLUTNING
+        MeldekortBehandlingStatus.UNDER_BESLUTNING -> MeldekortBehandlingStatusDTO.UNDER_BESLUTNING
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDTO.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatusDTO.AUTOMATISK_BEHANDLET

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
@@ -11,6 +11,7 @@ enum class MeldeperiodeKjedeStatusDTO {
     KLAR_TIL_BEHANDLING,
     UNDER_BEHANDLING,
     KLAR_TIL_BESLUTNING,
+    UNDER_BESLUTNING,
     GODKJENT,
     AUTOMATISK_BEHANDLET,
 }
@@ -20,6 +21,7 @@ fun Sak.toMeldeperiodeKjedeStatusDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock)
         return when (it.status) {
             MeldekortBehandlingStatus.GODKJENT -> MeldeperiodeKjedeStatusDTO.GODKJENT
             MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING -> MeldeperiodeKjedeStatusDTO.KLAR_TIL_BESLUTNING
+            MeldekortBehandlingStatus.UNDER_BESLUTNING -> MeldeperiodeKjedeStatusDTO.UNDER_BESLUTNING
             MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldeperiodeKjedeStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER
             MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldeperiodeKjedeStatusDTO.UNDER_BEHANDLING
             MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldeperiodeKjedeStatusDTO.AUTOMATISK_BEHANDLET

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
@@ -24,6 +24,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortSe
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppgaveMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.SendMeldeperiodeTilBrukerService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.TaMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.UnderkjennMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.OvertaMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
@@ -140,6 +141,13 @@ open class MeldekortContext(
 
     val overtaMeldekortBehandlingService by lazy {
         OvertaMeldekortBehandlingService(
+            tilgangsstyringService = tilgangsstyringService,
+            meldekortBehandlingRepo = meldekortBehandlingRepo,
+        )
+    }
+
+    val taMeldekortBehandlingService by lazy {
+        TaMeldekortBehandlingService(
             tilgangsstyringService = tilgangsstyringService,
             meldekortBehandlingRepo = meldekortBehandlingRepo,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
@@ -6,6 +6,7 @@ import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.persistering.domene.SessionContext
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlinger
 
 interface MeldekortBehandlingRepo {
@@ -37,6 +38,20 @@ interface MeldekortBehandlingRepo {
         meldekortId: MeldekortId,
         nySaksbehandler: Saksbehandler,
         nåværendeSaksbehandler: String,
+        sessionContext: SessionContext? = null,
+    ): Boolean
+
+    fun overtaBeslutter(
+        meldekortId: MeldekortId,
+        nyBeslutter: Saksbehandler,
+        nåværendeBeslutter: String,
+        sessionContext: SessionContext? = null,
+    ): Boolean
+
+    fun taBehandlingBeslutter(
+        meldekortId: MeldekortId,
+        beslutter: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
         sessionContext: SessionContext? = null,
     ): Boolean
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/IverksettMeldekortService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/IverksettMeldekortService.kt
@@ -62,7 +62,7 @@ class IverksettMeldekortService(
         require(meldekortBehandling is MeldekortBehandletManuelt) {
             "Meldekortet må være behandlet for å iverksettes"
         }
-        require(meldekortBehandling.beslutter == null && meldekortBehandling.status == MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING) {
+        require(meldekortBehandling.beslutter != null && meldekortBehandling.status == MeldekortBehandlingStatus.UNDER_BESLUTNING) {
             "Meldekort $meldekortId er allerede iverksatt"
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/TaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/TaMeldekortBehandlingService.kt
@@ -1,0 +1,51 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.service
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.KanIkkeTaBehandling
+import no.nav.tiltakspenger.saksbehandling.felles.exceptions.TilgangException
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
+
+class TaMeldekortBehandlingService(
+    private val tilgangsstyringService: TilgangsstyringService,
+    private val meldekortBehandlingRepo: MeldekortBehandlingRepo,
+) {
+    val logger = KotlinLogging.logger { }
+
+    suspend fun taMeldekortBehandling(
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler,
+        correlationId: CorrelationId,
+    ): Either<KanIkkeTaBehandling, MeldekortBehandling> {
+        val meldekortBehandling = meldekortBehandlingRepo.hent(meldekortId)
+            ?: throw IllegalStateException("Fant ikke meldekortBehandling for id $meldekortId")
+        tilgangsstyringService.harTilgangTilPerson(meldekortBehandling.fnr, saksbehandler.roller, correlationId)
+            .onLeft {
+                throw TilgangException("Feil ved tilgangssjekk til person når beslutter tar behandling. Feilen var $it")
+            }.onRight {
+                if (!it) throw TilgangException("Saksbehandler ${saksbehandler.navIdent} har ikke tilgang til person")
+            }
+
+        if (!saksbehandler.erBeslutter()) {
+            logger.warn { "Navident ${saksbehandler.navIdent} med rollene ${saksbehandler.roller} har ikke tilgang til å ta behandling" }
+            return KanIkkeTaBehandling.MåVæreSaksbehandlerEllerBeslutter.left()
+        }
+
+        return meldekortBehandling.taMeldekortBehandling(saksbehandler).also {
+            require(it.status == MeldekortBehandlingStatus.UNDER_BESLUTNING)
+            meldekortBehandlingRepo.taBehandlingBeslutter(
+                it.id,
+                saksbehandler,
+                it.status,
+            )
+        }.right()
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/UnderkjennMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/UnderkjennMeldekortBehandlingService.kt
@@ -23,7 +23,7 @@ class UnderkjennMeldekortBehandlingService(
             ?: throw IllegalStateException("Fant ikke meldekortBehandling for id ${command.meldekortId}")
 
         if (meldekortBehandling !is MeldekortBehandletManuelt) {
-            return KunneIkkeUnderkjenneMeldekortBehandling.BehandlingenErIkkeKlarTilBeslutning.left()
+            return KunneIkkeUnderkjenneMeldekortBehandling.BehandlingenErIkkeUnderBeslutning.left()
         }
 
         tilgangsstyringService.harTilgangTilPerson(meldekortBehandling.fnr, command.saksbehandler.roller, command.correlationId).onLeft {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
@@ -32,7 +32,11 @@ class OvertaMeldekortBehandlingService(
                     command.saksbehandler,
                     command.overtarFra,
                 )
-
+                MeldekortBehandlingStatus.UNDER_BESLUTNING -> meldekortBehandlingRepo.overtaBeslutter(
+                    it.id,
+                    command.saksbehandler,
+                    command.overtarFra,
+                )
                 MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
                 MeldekortBehandlingStatus.GODKJENT,
                 MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingManuellTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingManuellTest.kt
@@ -17,9 +17,9 @@ class MeldekortBehandlingManuellTest {
     @Test
     fun `underkjenner en MeldekortBehandlet`() {
         val meldekortBehandlet = ObjectMother.meldekortBehandletManuelt(
-            status = MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+            status = MeldekortBehandlingStatus.UNDER_BESLUTNING,
             iverksattTidspunkt = null,
-            beslutter = null,
+            beslutter = ObjectMother.saksbehandler().navIdent,
             opprettet = LocalDateTime.now(fixedClock),
         )
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingBuilder.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingBuilder.kt
@@ -1,0 +1,46 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.util.url
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.test.common.defaultRequest
+import no.nav.tiltakspenger.saksbehandling.common.TestApplicationContext
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+
+interface TaMeldekortBehandlingBuilder {
+    suspend fun ApplicationTestBuilder.taMeldekortBehanding(
+        tac: TestApplicationContext,
+        sakId: SakId,
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler = ObjectMother.saksbehandler(),
+    ): String {
+        defaultRequest(
+            HttpMethod.Post,
+            url {
+                protocol = URLProtocol.HTTPS
+                path("/sak/$sakId/meldekort/$meldekortId/ta")
+            },
+            jwt = tac.jwtGenerator.createJwtForSaksbehandler(
+                saksbehandler = saksbehandler,
+            ),
+        ).apply {
+            val bodyAsText = this.bodyAsText()
+            withClue(
+                "Response details:\n" + "Status: ${this.status}\n" + "Content-Type: ${this.contentType()}\n" + "Body: $bodyAsText\n",
+            ) {
+                status shouldBe HttpStatusCode.OK
+            }
+            return bodyAsText
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRouteTest.kt
@@ -1,0 +1,49 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import no.nav.tiltakspenger.saksbehandling.common.TestApplicationContext
+import no.nav.tiltakspenger.saksbehandling.infra.route.routes
+import no.nav.tiltakspenger.saksbehandling.infra.setup.jacksonSerialization
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.iverksett
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.taMeldekortBehanding
+import org.junit.jupiter.api.Test
+
+class TaMeldekortBehandlingRouteTest {
+    @Test
+    fun `beslutter kan ta meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val beslutterIdent = "Z12345"
+                val beslutter = ObjectMother.beslutter(navIdent = beslutterIdent)
+                val meldekortBehandling = ObjectMother.meldekortBehandletManuelt(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    beslutter = null,
+                    status = MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+                    iverksattTidspunkt = null,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                taMeldekortBehanding(tac, meldekortBehandling.sakId, meldekortBehandling.id, beslutter).also {
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.UNDER_BESLUTNING
+                    oppdatertMeldekortbehandling?.beslutter shouldBe beslutterIdent
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/BehandlingMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/BehandlingMother.kt
@@ -577,6 +577,11 @@ suspend fun TestApplicationContext.førsteMeldekortIverksatt(
         saksbehandler = saksbehandler,
         beslutter = beslutter,
     )
+    tac.meldekortContext.taMeldekortBehandlingService.taMeldekortBehandling(
+        meldekortId = sak.meldekortBehandlinger.first().id,
+        saksbehandler = beslutter,
+        correlationId = correlationId,
+    )
     tac.meldekortContext.iverksettMeldekortService.iverksettMeldekort(
         IverksettMeldekortKommando(
             meldekortId = sak.meldekortBehandlinger.first().id,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
@@ -451,7 +451,8 @@ interface MeldekortMother : MotherOfAllMothers {
                 clock,
             )
             .map { (meldekortBehandlinger, meldekort) ->
-                val iverksattMeldekort = meldekort.iverksettMeldekort(beslutter, clock).getOrFail()
+                val tildeltMeldekort = meldekort.taMeldekortBehandling(beslutter) as MeldekortBehandletManuelt
+                val iverksattMeldekort = tildeltMeldekort.iverksettMeldekort(beslutter, clock).getOrFail()
                 val oppdaterteBehandlinger = meldekortBehandlinger.oppdaterMeldekortbehandling(iverksattMeldekort)
                 Pair(oppdaterteBehandlinger, iverksattMeldekort)
             }
@@ -516,7 +517,8 @@ interface MeldekortMother : MotherOfAllMothers {
             clock,
         )
             .map { (meldekortBehandlinger, meldekort) ->
-                val iverksattMeldekort = meldekort.iverksettMeldekort(beslutter, clock).getOrFail()
+                val tildeltMeldekort = meldekort.taMeldekortBehandling(beslutter) as MeldekortBehandletManuelt
+                val iverksattMeldekort = tildeltMeldekort.iverksettMeldekort(beslutter, clock).getOrFail()
                 val oppdaterteBehandlinger = meldekortBehandlinger.oppdaterMeldekortbehandling(iverksattMeldekort)
                 Pair(oppdaterteBehandlinger, iverksattMeldekort)
             }.getOrFail().first

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/routes/RouteBuilder.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/routes/RouteBuilder.kt
@@ -9,6 +9,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.infra.route.start.StartBeh
 import no.nav.tiltakspenger.saksbehandling.behandling.infra.route.taOgOverta.OvertaBehandlingBuilder
 import no.nav.tiltakspenger.saksbehandling.behandling.infra.route.taOgOverta.TaBehandlingBuilder
 import no.nav.tiltakspenger.saksbehandling.behandling.infra.route.tilbeslutter.SendFørstegangsbehandlingTilBeslutningBuilder
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.TaMeldekortBehandlingBuilder
 import no.nav.tiltakspenger.saksbehandling.routes.revurdering.SendRevurderingTilBeslutterBuilder
 import no.nav.tiltakspenger.saksbehandling.routes.revurdering.StartRevurderingBuilder
 import no.nav.tiltakspenger.saksbehandling.sak.infra.routes.OpprettSakRouteBuilder
@@ -27,4 +28,5 @@ object RouteBuilder :
     IverksettBehandlingBuilder,
     StartRevurderingBuilder,
     OppdaterSaksopplysningerBuilder,
-    OvertaBehandlingBuilder
+    OvertaBehandlingBuilder,
+    TaMeldekortBehandlingBuilder

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/OpprettUtbetalingsvedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/service/OpprettUtbetalingsvedtakServiceTest.kt
@@ -21,6 +21,11 @@ internal class OpprettUtbetalingsvedtakServiceTest {
             meldekortContext.oppdaterMeldekortService.sendMeldekortTilBeslutter(
                 sak.meldekortBehandlinger[1].tilOppdaterMeldekortKommando(ObjectMother.saksbehandler()),
             )
+            meldekortContext.taMeldekortBehandlingService.taMeldekortBehandling(
+                meldekortId = sak.meldekortBehandlinger[1].id,
+                saksbehandler = ObjectMother.beslutter(),
+                correlationId = CorrelationId.generate(),
+            )
             meldekortContext.iverksettMeldekortService.iverksettMeldekort(
                 IverksettMeldekortKommando(
                     meldekortId = sak.meldekortBehandlinger[1].id,


### PR DESCRIPTION
Innfører en ny status UNDER_BESLUTNING. Når et meldekort setter til KLAR_TIL_BESLUTNING må beslutter velge å tildele behandlingen til seg selv. Da settes beslutter til den aktuelle beslutteren, og statusen blir UNDER_BESLUTNING. Man kan ikke iverksette fra andre statuser enn UNDER_BESLUTNING. 

Hvis behandlingen er UNDER_BESLUTNING kan også en annen beslutter velge å overta behandlingen. 

https://trello.com/c/iYXkiirR/1458-en-p%C3%A5startet-manuell-meldekortbehandling-m%C3%A5-kunne-overtas-av-en-annen-saksbehandler