### PR TITLE
1472 må hente evt oppgave fra brukers meldekort i databasen

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
@@ -68,6 +68,7 @@ open class MeldekortContext(
         IverksettMeldekortService(
             meldekortBehandlingRepo = meldekortBehandlingRepo,
             meldeperiodeRepo = meldeperiodeRepo,
+            brukersMeldekortRepo = brukersMeldekortRepo,
             sessionFactory = sessionFactory,
             sakService = sakService,
             utbetalingsvedtakRepo = utbetalingsvedtakRepo,


### PR DESCRIPTION
For meldekort som behandles manuelt har vi ikke noen kobling til brukers meldekort på selve meldekortbehandling-objektet. For å se om vi skal ferdigstille en oppgave må vi slå opp i meldekort_bruker-tabellen for å se om det finnes et meldekort med en oppgave knyttet til seg for samme meldeperiode. Hvis det gjør det kan vi ferdigstille den. 

https://trello.com/c/D2IoW0Tx/1472-oppgaven-for-mottatt-meldekort-blir-ikke-ferdigstilt-automatisk