### PR TITLE
Meldekort legg tilbake

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
@@ -59,6 +59,7 @@ fun Route.routes(
         underkjennMeldekortBehandlingService = applicationContext.meldekortContext.underkjennMeldekortBehandlingService,
         overtaMeldekortBehandlingService = applicationContext.meldekortContext.overtaMeldekortBehandlingService,
         taMeldekortBehandlingService = applicationContext.meldekortContext.taMeldekortBehandlingService,
+        leggTilbakeMeldekortBehandlingService = applicationContext.meldekortContext.leggTilbakeMeldekortBehandlingService,
         clock = applicationContext.clock,
     )
     mottaSøknadRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KanIkkeLeggeTilbakeMeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KanIkkeLeggeTilbakeMeldekortBehandling.kt
@@ -1,0 +1,6 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene
+
+sealed interface KanIkkeLeggeTilbakeMeldekortBehandling {
+    data object MåVæreSaksbehandlerEllerBeslutter : KanIkkeLeggeTilbakeMeldekortBehandling
+    data object MåVæreSaksbehandlerEllerBeslutterForBehandlingen : KanIkkeLeggeTilbakeMeldekortBehandling
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
@@ -62,6 +62,10 @@ data class MeldekortBehandletAutomatisk(
     override fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling {
         throw IllegalStateException("Kan ikke tildele automatisk behandlet meldekort")
     }
+
+    override fun leggTilbakeMeldekortBehandling(saksbehandler: Saksbehandler): Either<KanIkkeLeggeTilbakeMeldekortBehandling, MeldekortBehandling> {
+        throw IllegalStateException("Kan ikke legge tilbake automatisk behandlet meldekort")
+    }
 }
 
 fun Sak.opprettAutomatiskMeldekortBehandling(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -107,6 +107,8 @@ sealed interface MeldekortBehandling {
 
     fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling
 
+    fun leggTilbakeMeldekortBehandling(saksbehandler: Saksbehandler): Either<KanIkkeLeggeTilbakeMeldekortBehandling, MeldekortBehandling>
+
     sealed interface Behandlet : MeldekortBehandling {
         override val beregning: MeldekortBeregning
         override val beløpTotal: Int get() = beregning.beregnTotaltBeløp()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -47,7 +47,7 @@ sealed interface MeldekortBehandling {
     val fraOgMed: LocalDate get() = periode.fraOgMed
     val tilOgMed: LocalDate get() = periode.tilOgMed
 
-    val saksbehandler: String
+    val saksbehandler: String?
     val beslutter: String?
     val status: MeldekortBehandlingStatus
     val navkontor: Navkontor

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
@@ -203,6 +203,26 @@ class MeldekortBehandlingPostgresRepo(
         }
     }
 
+    override fun taBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        return sessionFactory.withSession(sessionContext) { sx ->
+            sx.run(
+                queryOf(
+                    """update meldekortbehandling set saksbehandler = :saksbehandler, status = :status where id = :id and saksbehandler is null""",
+                    mapOf(
+                        "id" to meldekortId.toString(),
+                        "saksbehandler" to saksbehandler.navIdent,
+                        "status" to meldekortBehandlingStatus.toDb(),
+                    ),
+                ).asUpdate,
+            ) > 0
+        }
+    }
+
     override fun taBehandlingBeslutter(
         meldekortId: MeldekortId,
         beslutter: Saksbehandler,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
@@ -243,6 +243,46 @@ class MeldekortBehandlingPostgresRepo(
         }
     }
 
+    override fun leggTilbakeBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        nåværendeSaksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        return sessionFactory.withSession(sessionContext) { sx ->
+            sx.run(
+                queryOf(
+                    """update meldekortbehandling set saksbehandler = null, status = :status where id = :id and saksbehandler = :lagretSaksbehandler""",
+                    mapOf(
+                        "id" to meldekortId.toString(),
+                        "lagretSaksbehandler" to nåværendeSaksbehandler.navIdent,
+                        "status" to meldekortBehandlingStatus.toDb(),
+                    ),
+                ).asUpdate,
+            ) > 0
+        }
+    }
+
+    override fun leggTilbakeBehandlingBeslutter(
+        meldekortId: MeldekortId,
+        nåværendeBeslutter: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        return sessionFactory.withSession(sessionContext) { sx ->
+            sx.run(
+                queryOf(
+                    """update meldekortbehandling set beslutter = null, status = :status where id = :id and beslutter = :lagretBeslutter""",
+                    mapOf(
+                        "id" to meldekortId.toString(),
+                        "lagretBeslutter" to nåværendeBeslutter.navIdent,
+                        "status" to meldekortBehandlingStatus.toDb(),
+                    ),
+                ).asUpdate,
+            ) > 0
+        }
+    }
+
     companion object {
         internal fun hentForMeldekortId(
             meldekortId: MeldekortId,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
@@ -352,7 +352,7 @@ class MeldekortBehandlingPostgresRepo(
             val navkontor = Navkontor(kontornummer = navkontorEnhetsnummer, kontornavn = navkontorNavn)
             val attesteringer = row.string("attesteringer").toAttesteringer().toAttesteringer()
 
-            val saksbehandler = row.string("saksbehandler")
+            val saksbehandler = row.stringOrNull("saksbehandler")
 
             val dager = row.string("meldekortdager").tilMeldekortDager(maksDagerMedTiltakspengerForPeriode)
             val beregning = row.stringOrNull("beregninger")?.tilBeregninger(id)?.let {
@@ -399,7 +399,7 @@ class MeldekortBehandlingPostgresRepo(
                         ikkeRettTilTiltakspengerTidspunkt = ikkeRettTilTiltakspengerTidspunkt,
                         brukersMeldekort = brukersMeldekort,
                         meldeperiode = meldeperiode,
-                        saksbehandler = saksbehandler,
+                        saksbehandler = saksbehandler!!,
                         type = type,
                         begrunnelse = begrunnelse,
                         attesteringer = attesteringer,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortBehandlingRoute.kt
@@ -1,0 +1,62 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.tiltakspenger.libs.auth.core.TokenService
+import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.respond400BadRequest
+import no.nav.tiltakspenger.libs.ktor.common.respond403Forbidden
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
+import no.nav.tiltakspenger.saksbehandling.infra.repo.Standardfeil.måVæreSaksbehandlerEllerBeslutter
+import no.nav.tiltakspenger.saksbehandling.infra.repo.correlationId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMeldekortId
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeLeggeTilbakeMeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.UtbetalingsstatusDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.toMeldekortBehandlingDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortBehandlingService
+
+private const val LEGG_TILBAKE_MELDEKORTBEHANDLING_PATH = "/sak/{sakId}/meldekort/{meldekortId}/legg-tilbake"
+
+fun Route.leggTilbakeMeldekortBehandlingRoute(
+    tokenService: TokenService,
+    auditService: AuditService,
+    leggTilbakeMeldekortBehandlingService: LeggTilbakeMeldekortBehandlingService,
+) {
+    val logger = KotlinLogging.logger {}
+    post(LEGG_TILBAKE_MELDEKORTBEHANDLING_PATH) {
+        logger.debug { "Mottatt post-request på '$LEGG_TILBAKE_MELDEKORTBEHANDLING_PATH' - Fjerner saksbehandler/beslutter fra meldekortbehandlingen." }
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withMeldekortId { meldekortId ->
+                val correlationId = call.correlationId()
+
+                leggTilbakeMeldekortBehandlingService.leggTilbakeMeldekortBehandling(meldekortId, saksbehandler, correlationId = correlationId).fold(
+                    {
+                        when (it) {
+                            KanIkkeLeggeTilbakeMeldekortBehandling.MåVæreSaksbehandlerEllerBeslutter -> call.respond403Forbidden(måVæreSaksbehandlerEllerBeslutter())
+                            KanIkkeLeggeTilbakeMeldekortBehandling.MåVæreSaksbehandlerEllerBeslutterForBehandlingen -> call.respond400BadRequest(
+                                "Du kan ikke legge tilbake en meldekortbehandling som ikke er tildelt deg",
+                                "må_være_saksbehandler_eller_beslutter_for_meldekortbehandlingen",
+                            )
+                        }
+                    },
+
+                    {
+                        auditService.logMedMeldekortId(
+                            meldekortId = meldekortId,
+                            navIdent = saksbehandler.navIdent,
+                            action = AuditLogEvent.Action.UPDATE,
+                            contextMessage = "Saksbehandler fjernes fra meldekortbehandlingen",
+                            correlationId = correlationId,
+                        )
+
+                        call.respond(status = HttpStatusCode.OK, it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.IKKE_GODKJENT))
+                    },
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
@@ -6,6 +6,7 @@ import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.frameldekortapi.mottaMeldekortRoutes
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.IverksettMeldekortService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.MottaBrukerutfyltMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
@@ -25,6 +26,7 @@ fun Route.meldekortRoutes(
     underkjennMeldekortBehandlingService: UnderkjennMeldekortBehandlingService,
     overtaMeldekortBehandlingService: OvertaMeldekortBehandlingService,
     taMeldekortBehandlingService: TaMeldekortBehandlingService,
+    leggTilbakeMeldekortBehandlingService: LeggTilbakeMeldekortBehandlingService,
     clock: Clock,
 ) {
     hentMeldekortRoute(sakService, auditService, tokenService, clock)
@@ -36,4 +38,5 @@ fun Route.meldekortRoutes(
     mottaMeldekortRoutes(mottaBrukerutfyltMeldekortService)
     taMeldekortBehandlingRoute(tokenService, auditService, taMeldekortBehandlingService)
     underkjennMeldekortBehandlingRoute(underkjennMeldekortBehandlingService, auditService, tokenService)
+    leggTilbakeMeldekortBehandlingRoute(tokenService, auditService, leggTilbakeMeldekortBehandlingService)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingDTO.kt
@@ -13,7 +13,7 @@ data class MeldekortBehandlingDTO(
     val id: String,
     val meldeperiodeId: String,
     val brukersMeldekortId: String?,
-    val saksbehandler: String,
+    val saksbehandler: String?,
     val beslutter: String?,
     val opprettet: LocalDateTime,
     val godkjentTidspunkt: LocalDateTime?,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
@@ -20,6 +20,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRe
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.AutomatiskMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.IverksettMeldekortService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppgaveMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OpprettMeldekortBehandlingService
@@ -149,6 +150,13 @@ open class MeldekortContext(
 
     val taMeldekortBehandlingService by lazy {
         TaMeldekortBehandlingService(
+            tilgangsstyringService = tilgangsstyringService,
+            meldekortBehandlingRepo = meldekortBehandlingRepo,
+        )
+    }
+
+    val leggTilbakeMeldekortBehandlingService by lazy {
+        LeggTilbakeMeldekortBehandlingService(
             tilgangsstyringService = tilgangsstyringService,
             meldekortBehandlingRepo = meldekortBehandlingRepo,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
@@ -48,6 +48,13 @@ interface MeldekortBehandlingRepo {
         sessionContext: SessionContext? = null,
     ): Boolean
 
+    fun taBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext? = null,
+    ): Boolean
+
     fun taBehandlingBeslutter(
         meldekortId: MeldekortId,
         beslutter: Saksbehandler,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/ports/MeldekortBehandlingRepo.kt
@@ -61,4 +61,18 @@ interface MeldekortBehandlingRepo {
         meldekortBehandlingStatus: MeldekortBehandlingStatus,
         sessionContext: SessionContext? = null,
     ): Boolean
+
+    fun leggTilbakeBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        nåværendeSaksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext? = null,
+    ): Boolean
+
+    fun leggTilbakeBehandlingBeslutter(
+        meldekortId: MeldekortId,
+        nåværendeBeslutter: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext? = null,
+    ): Boolean
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsvedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsvedtak.kt
@@ -40,7 +40,7 @@ data class Utbetalingsvedtak(
     val totalBeløp: Int = meldekortbehandling.beløpTotal
     val meldekortId: MeldekortId = meldekortbehandling.id
     val kjedeId: MeldeperiodeKjedeId = meldekortbehandling.kjedeId
-    val saksbehandler: String = meldekortbehandling.saksbehandler
+    val saksbehandler: String = meldekortbehandling.saksbehandler!!
     val beslutter: String = meldekortbehandling.beslutter!!
     val brukerNavkontor: Navkontor = meldekortbehandling.navkontor
     val meldeperiode: Meldeperiode = meldekortbehandling.meldeperiode

--- a/src/main/resources/db/migration/V78__meldekortbehandling_saksbehandler_nullable.sql
+++ b/src/main/resources/db/migration/V78__meldekortbehandling_saksbehandler_nullable.sql
@@ -1,0 +1,1 @@
+alter table meldekortbehandling alter column saksbehandler drop not null;

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/MeldekortBehandlingFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/MeldekortBehandlingFakeRepo.kt
@@ -128,6 +128,47 @@ class MeldekortBehandlingFakeRepo : MeldekortBehandlingRepo {
         }
     }
 
+    override fun leggTilbakeBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        nåværendeSaksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        val meldekortBehandling = data.get()[meldekortId]
+        require(meldekortBehandling != null && meldekortBehandling.saksbehandler == nåværendeSaksbehandler.navIdent && meldekortBehandling.status == MeldekortBehandlingStatus.UNDER_BEHANDLING) {
+            "Meldekortbehandling med id $meldekortId finnes ikke eller har ikke saksbehandler $nåværendeSaksbehandler"
+        }
+        if (meldekortBehandling is MeldekortUnderBehandling) {
+            data.get()[meldekortId] = meldekortBehandling.copy(
+                saksbehandler = null,
+            )
+            return true
+        } else {
+            throw IllegalStateException("Kan ikke fjerne saksbehandler for meldekort som ikke er under behandling")
+        }
+    }
+
+    override fun leggTilbakeBehandlingBeslutter(
+        meldekortId: MeldekortId,
+        nåværendeBeslutter: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        val meldekortBehandling = data.get()[meldekortId]
+        require(meldekortBehandling != null && meldekortBehandling.beslutter == nåværendeBeslutter.navIdent && meldekortBehandling.status == MeldekortBehandlingStatus.UNDER_BESLUTNING) {
+            "Meldekortbehandling med id $meldekortId finnes ikke eller har ikke beslutter $nåværendeBeslutter"
+        }
+        if (meldekortBehandling is MeldekortBehandletManuelt) {
+            data.get()[meldekortId] = meldekortBehandling.copy(
+                beslutter = null,
+                status = MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+            )
+            return true
+        } else {
+            throw IllegalStateException("Kan ikke endre beslutter for meldekort som ikke er manuelt behandlet")
+        }
+    }
+
     fun hentFnrForMeldekortId(
         meldekortId: MeldekortId,
     ): Fnr? = data.get()[meldekortId]?.fnr

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/MeldekortBehandlingFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/MeldekortBehandlingFakeRepo.kt
@@ -87,6 +87,26 @@ class MeldekortBehandlingFakeRepo : MeldekortBehandlingRepo {
         }
     }
 
+    override fun taBehandlingSaksbehandler(
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler,
+        meldekortBehandlingStatus: MeldekortBehandlingStatus,
+        sessionContext: SessionContext?,
+    ): Boolean {
+        val meldekortBehandling = data.get()[meldekortId]
+        require(meldekortBehandling != null && meldekortBehandling.saksbehandler == null && meldekortBehandling.status == MeldekortBehandlingStatus.UNDER_BEHANDLING) {
+            "Meldekortbehandling med id $meldekortId finnes ikke eller har ikke status UNDER_BEHANDLING eller har allerede saksbehandler"
+        }
+        if (meldekortBehandling is MeldekortUnderBehandling) {
+            data.get()[meldekortId] = meldekortBehandling.copy(
+                saksbehandler = saksbehandler.navIdent,
+            )
+            return true
+        } else {
+            throw IllegalStateException("Kan ikke endre saksbehandler for meldekort som ikke er under behandling")
+        }
+    }
+
     override fun taBehandlingBeslutter(
         meldekortId: MeldekortId,
         beslutter: Saksbehandler,

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/LeggTilbakeMeldekortBehandlingRouteTest.kt
@@ -1,0 +1,127 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.util.url
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.test.common.defaultRequest
+import no.nav.tiltakspenger.saksbehandling.common.TestApplicationContext
+import no.nav.tiltakspenger.saksbehandling.infra.route.routes
+import no.nav.tiltakspenger.saksbehandling.infra.setup.jacksonSerialization
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.iverksett
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.taMeldekortBehanding
+import org.junit.jupiter.api.Test
+
+class LeggTilbakeMeldekortBehandlingRouteTest {
+    @Test
+    fun `beslutter kan legge tilbake meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val beslutterIdent = "Z12345"
+                val beslutter = ObjectMother.beslutter(navIdent = beslutterIdent)
+                val meldekortBehandling = ObjectMother.meldekortBehandletManuelt(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    beslutter = null,
+                    status = MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+                    iverksattTidspunkt = null,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                taMeldekortBehanding(tac, meldekortBehandling.sakId, meldekortBehandling.id, beslutter).also {
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.UNDER_BESLUTNING
+                    oppdatertMeldekortbehandling?.beslutter shouldBe beslutterIdent
+                }
+
+                leggTilbakeMeldekortBehandling(tac, meldekortBehandling.sakId, meldekortBehandling.id, beslutter).also {
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
+                    oppdatertMeldekortbehandling?.beslutter shouldBe null
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `saksbehandler kan legge tilbake meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val saksbehandlerIdent = "Z12345"
+                val saksbehandler = ObjectMother.saksbehandler(navIdent = saksbehandlerIdent)
+                val meldekortBehandling = ObjectMother.meldekortUnderBehandling(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    saksbehandler = saksbehandlerIdent,
+                    status = MeldekortBehandlingStatus.UNDER_BEHANDLING,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                leggTilbakeMeldekortBehandling(tac, meldekortBehandling.sakId, meldekortBehandling.id, saksbehandler).also {
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.UNDER_BEHANDLING
+                    oppdatertMeldekortbehandling?.saksbehandler shouldBe null
+                }
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.leggTilbakeMeldekortBehandling(
+        tac: TestApplicationContext,
+        sakId: SakId,
+        meldekortId: MeldekortId,
+        saksbehandler: Saksbehandler = ObjectMother.saksbehandler(),
+    ): String {
+        defaultRequest(
+            HttpMethod.Post,
+            url {
+                protocol = URLProtocol.HTTPS
+                path("/sak/$sakId/meldekort/$meldekortId/legg-tilbake")
+            },
+            jwt = tac.jwtGenerator.createJwtForSaksbehandler(
+                saksbehandler = saksbehandler,
+            ),
+        ).apply {
+            val bodyAsText = this.bodyAsText()
+            withClue(
+                "Response details:\n" + "Status: ${this.status}\n" + "Content-Type: ${this.contentType()}\n" + "Body: $bodyAsText\n",
+            ) {
+                status shouldBe HttpStatusCode.OK
+            }
+            return bodyAsText
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/TaMeldekortBehandlingRouteTest.kt
@@ -46,4 +46,36 @@ class TaMeldekortBehandlingRouteTest {
             }
         }
     }
+
+    @Test
+    fun `saksbehandler kan ta meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val saksbehandlerIdent = "Z12345"
+                val saksbehandler = ObjectMother.saksbehandler(navIdent = saksbehandlerIdent)
+                val meldekortBehandling = ObjectMother.meldekortUnderBehandling(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    saksbehandler = null,
+                    status = MeldekortBehandlingStatus.UNDER_BEHANDLING,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                taMeldekortBehanding(tac, meldekortBehandling.sakId, meldekortBehandling.id, saksbehandler).also {
+                    val oppdatertMeldekortbehandling = tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.UNDER_BEHANDLING
+                    oppdatertMeldekortbehandling?.saksbehandler shouldBe saksbehandlerIdent
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/objectmothers/MeldekortMother.kt
@@ -63,7 +63,7 @@ interface MeldekortMother : MotherOfAllMothers {
         fnr: Fnr = Fnr.random(),
         periode: Periode = Periode(6.januar(2025), 19.januar(2025)),
         kjedeId: MeldeperiodeKjedeId = MeldeperiodeKjedeId.fraPeriode(periode),
-        saksbehandler: String = "saksbehandler",
+        saksbehandler: String? = "saksbehandler",
         beslutter: String = "beslutter",
         tiltakstype: TiltakstypeSomGirRett = TiltakstypeSomGirRett.GRUPPE_AMO,
         status: MeldekortBehandlingStatus = MeldekortBehandlingStatus.GODKJENT,


### PR DESCRIPTION
- Gjør saksbehandler optional på meldekortbehandlingen slik at saksbehandler kan fjerne seg selv
- Saksbehandler må kunne tildele seg selv hvis det ikke er angitt noen saksbehandler
- Saksbehandler og beslutter skal kunne legge tilbake meldekortbehandlingen

https://trello.com/c/gMr9XKsr/1468-legg-tilbake-behandling-saksbehandler-og-beslutter-meldekort-og-s%C3%B8knadsbehandling