### PR TITLE
1078 deler alle saksbehandlingsoverganger med statistikk

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/setup/BehandlingOgVedtakContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/setup/BehandlingOgVedtakContext.kt
@@ -34,6 +34,7 @@ import no.nav.tiltakspenger.saksbehandling.distribusjon.Dokumentdistribusjonskli
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.NavIdentClient
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakService
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltagelse.infra.TiltaksdeltagelseGateway
 import no.nav.tiltakspenger.saksbehandling.vedtak.infra.repo.RammevedtakPostgresRepo
 import java.time.Clock
@@ -47,7 +48,6 @@ open class BehandlingOgVedtakContext(
     meldeperiodeRepo: MeldeperiodeRepo,
     statistikkSakRepo: StatistikkSakRepo,
     statistikkStønadRepo: StatistikkStønadRepo,
-    gitHash: String,
     journalførVedtaksbrevGateway: JournalførVedtaksbrevGateway,
     genererVedtaksbrevGateway: GenererInnvilgelsesvedtaksbrevGateway,
     genererStansvedtaksbrevGateway: GenererStansvedtaksbrevGateway,
@@ -58,6 +58,7 @@ open class BehandlingOgVedtakContext(
     sakService: SakService,
     tiltaksdeltagelseGateway: TiltaksdeltagelseGateway,
     oppgaveGateway: OppgaveGateway,
+    statistikkSakService: StatistikkSakService,
     clock: Clock,
 ) {
     open val rammevedtakRepo: RammevedtakRepo by lazy { RammevedtakPostgresRepo(sessionFactory as PostgresSessionFactory) }
@@ -73,18 +74,19 @@ open class BehandlingOgVedtakContext(
             tilgangsstyringService = tilgangsstyringService,
             personService = personService,
             clock = clock,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
     val startSøknadsbehandlingService: StartSøknadsbehandlingService by lazy {
         StartSøknadsbehandlingService(
             sakService = sakService,
             sessionFactory = sessionFactory,
-            tilgangsstyringService = tilgangsstyringService,
-            gitHash = gitHash,
             behandlingRepo = behandlingRepo,
             statistikkSakRepo = statistikkSakRepo,
             oppdaterSaksopplysningerService = oppdaterSaksopplysningerService,
             clock = clock,
+            statistikkSakService = statistikkSakService,
         )
     }
     val oppdaterSaksopplysningerService: OppdaterSaksopplysningerService by lazy {
@@ -117,12 +119,10 @@ open class BehandlingOgVedtakContext(
             sessionFactory = sessionFactory,
             statistikkSakRepo = statistikkSakRepo,
             statistikkStønadRepo = statistikkStønadRepo,
-            tilgangsstyringService = tilgangsstyringService,
-            personService = personService,
-            gitHash = gitHash,
             sakService = sakService,
             oppgaveGateway = oppgaveGateway,
             clock = clock,
+            statistikkSakService = statistikkSakService,
         )
     }
 
@@ -131,6 +131,8 @@ open class BehandlingOgVedtakContext(
             sakService = sakService,
             behandlingRepo = behandlingRepo,
             clock = clock,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
     val startRevurderingService: StartRevurderingService by lazy {
@@ -140,6 +142,8 @@ open class BehandlingOgVedtakContext(
             tilgangsstyringService = tilgangsstyringService,
             saksopplysningerService = oppdaterSaksopplysningerService,
             clock = clock,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
     val oppdaterBarnetilleggService: OppdaterBarnetilleggService by lazy {
@@ -183,6 +187,8 @@ open class BehandlingOgVedtakContext(
         TaBehandlingService(
             tilgangsstyringService = tilgangsstyringService,
             behandlingRepo = behandlingRepo,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
 
@@ -191,6 +197,8 @@ open class BehandlingOgVedtakContext(
             tilgangsstyringService = tilgangsstyringService,
             behandlingRepo = behandlingRepo,
             clock = clock,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
 
@@ -198,6 +206,8 @@ open class BehandlingOgVedtakContext(
         LeggTilbakeBehandlingService(
             tilgangsstyringService = tilgangsstyringService,
             behandlingRepo = behandlingRepo,
+            statistikkSakService = statistikkSakService,
+            statistikkSakRepo = statistikkSakRepo,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkSakRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkSakRepo.kt
@@ -3,7 +3,7 @@ package no.nav.tiltakspenger.saksbehandling.behandling.ports
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.StatistikkSakDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakDTO
 
 interface StatistikkSakRepo {
     fun lagre(dto: StatistikkSakDTO, context: TransactionContext? = null)

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkStønadRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/StatistikkStønadRepo.kt
@@ -3,8 +3,8 @@ package no.nav.tiltakspenger.saksbehandling.behandling.ports
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkStønadDTO
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkUtbetalingDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkStønadDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkUtbetalingDTO
 
 interface StatistikkStønadRepo {
     fun lagre(dto: StatistikkStønadDTO, context: TransactionContext? = null)

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/StartRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/service/sak/StartRevurderingService.kt
@@ -15,10 +15,12 @@ import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandling
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.StartRevurderingKommando
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.startRevurdering
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.BehandlingRepo
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.service.behandling.OppdaterSaksopplysningerService
 import no.nav.tiltakspenger.saksbehandling.felles.exceptions.IkkeFunnetException
 import no.nav.tiltakspenger.saksbehandling.felles.exceptions.TilgangException
 import no.nav.tiltakspenger.saksbehandling.sak.Sak
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakService
 import java.time.Clock
 
 class StartRevurderingService(
@@ -27,6 +29,8 @@ class StartRevurderingService(
     private val tilgangsstyringService: TilgangsstyringService,
     private val saksopplysningerService: OppdaterSaksopplysningerService,
     private val clock: Clock,
+    private val statistikkSakService: StatistikkSakService,
+    private val statistikkSakRepo: StatistikkSakRepo,
 ) {
     val logger = KotlinLogging.logger { }
 
@@ -54,6 +58,7 @@ class StartRevurderingService(
             .getOrElse { return it.left() }
 
         behandlingRepo.lagre(behandling)
+        statistikkSakRepo.lagre(statistikkSakService.genererStatistikkForRevurdering(behandling))
         return Pair(oppdatertSak, behandling).right()
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
@@ -207,7 +207,7 @@ open class ApplicationContext(
 
     open val personContext by lazy { PersonContext(sessionFactory, entraIdSystemtokenClient) }
     open val dokumentContext by lazy { DokumentContext(entraIdSystemtokenClient) }
-    open val statistikkContext by lazy { StatistikkContext(sessionFactory, clock) }
+    open val statistikkContext by lazy { StatistikkContext(sessionFactory, personContext.tilgangsstyringService, gitHash, clock) }
     open val søknadContext by lazy { SøknadContext(sessionFactory, oppgaveGateway) }
     open val tiltakContext by lazy { TiltaksdeltagelseContext(entraIdSystemtokenClient) }
     open val profile by lazy { Configuration.applicationProfile() }
@@ -254,7 +254,6 @@ open class ApplicationContext(
             meldeperiodeRepo = meldekortContext.meldeperiodeRepo,
             statistikkSakRepo = statistikkContext.statistikkSakRepo,
             statistikkStønadRepo = statistikkContext.statistikkStønadRepo,
-            gitHash = gitHash,
             journalførVedtaksbrevGateway = dokumentContext.journalførVedtaksbrevGateway,
             genererVedtaksbrevGateway = dokumentContext.genererInnvilgelsesvedtaksbrevGateway,
             genererStansvedtaksbrevGateway = dokumentContext.genererStansvedtaksbrevGateway,
@@ -266,6 +265,7 @@ open class ApplicationContext(
             tiltaksdeltagelseGateway = tiltakContext.tiltaksdeltagelseGateway,
             oppgaveGateway = oppgaveGateway,
             clock = clock,
+            statistikkSakService = statistikkContext.statistikkSakService,
         )
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/StatistikkContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/StatistikkContext.kt
@@ -2,16 +2,28 @@ package no.nav.tiltakspenger.saksbehandling.statistikk
 
 import no.nav.tiltakspenger.libs.persistering.domene.SessionFactory
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
+import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
-import no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.sak.StatistikkSakRepoImpl
-import no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.stønad.StatistikkStønadPostgresRepo
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakRepoImpl
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakService
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkStønadPostgresRepo
 import java.time.Clock
 
 open class StatistikkContext(
     sessionFactory: SessionFactory,
+    tilgangsstyringService: TilgangsstyringService,
+    gitHash: String,
     clock: Clock,
 ) {
     open val statistikkSakRepo: StatistikkSakRepo by lazy { StatistikkSakRepoImpl(sessionFactory as PostgresSessionFactory) }
     open val statistikkStønadRepo: StatistikkStønadRepo by lazy { StatistikkStønadPostgresRepo(sessionFactory as PostgresSessionFactory, clock) }
+
+    val statistikkSakService: StatistikkSakService by lazy {
+        StatistikkSakService(
+            tilgangsstyringService = tilgangsstyringService,
+            gitHash = gitHash,
+            clock = clock,
+        )
+    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak
+package no.nav.tiltakspenger.saksbehandling.statistikk.behandling
 
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -33,14 +33,14 @@ data class StatistikkSakDTO(
     /** Tidspunktet da fagsystemet legger hendelsen på grensesnittet/topicen. */
     val tekniskTidspunkt: LocalDateTime,
     // IND
-    val sakYtelse: String,
+    val sakYtelse: String = "IND",
     val behandlingType: BehandlingType,
     val behandlingStatus: BehandlingStatus,
     val behandlingResultat: BehandlingResultat?,
     // fylles ut ved klage, avvisning, avslag
     val resultatBegrunnelse: String?,
     // manuell, automatisk
-    val behandlingMetode: String,
+    val behandlingMetode: String = BehandlingMetode.MANUELL.name,
     // Settes til -5 hvis kode 6 kan være systembruker
     val opprettetAv: String,
     // Settes til -5 hvis kode 6
@@ -53,7 +53,7 @@ data class StatistikkSakDTO(
     val funksjonellPeriodeFom: LocalDate?,
     /** Kun for tilbakekreving: funksjonell periode for tilbakekreving */
     val funksjonellPeriodeTom: LocalDate?,
-    val avsender: String,
+    val avsender: String = "tiltakspenger-saksbehandling-api",
     // commit hash
     val versjon: String,
     val hendelse: String,
@@ -82,6 +82,7 @@ enum class BehandlingResultat {
 
 enum class BehandlingStatus {
     UNDER_BEHANDLING,
+    UNDER_BESLUTNING,
     FERDIG_BEHANDLET,
     AVSLUTTET,
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakMapper.kt
@@ -1,55 +1,13 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak
+package no.nav.tiltakspenger.saksbehandling.statistikk.behandling
 
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandling
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandlingsstatus
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.ValgtHjemmelForStans
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.ValgtHjemmelHarIkkeRettighet
 import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtak
 import no.nav.tiltakspenger.saksbehandling.vedtak.Vedtakstype
 import java.time.Clock
-
-fun genererStatistikkForNyFørstegangsbehandling(
-    behandling: Behandling,
-    gjelderKode6: Boolean,
-    versjon: String,
-    clock: Clock,
-): StatistikkSakDTO {
-    return StatistikkSakDTO(
-        sakId = behandling.sakId.toString(),
-        saksnummer = behandling.saksnummer.toString(),
-        behandlingId = behandling.id.toString(),
-        relatertBehandlingId = null,
-        fnr = behandling.fnr.verdi,
-        mottattTidspunkt = behandling.søknad!!.opprettet,
-        registrertTidspunkt = behandling.opprettet,
-        ferdigBehandletTidspunkt = null,
-        vedtakTidspunkt = null,
-        endretTidspunkt = nå(clock),
-        utbetaltTidspunkt = null,
-        tekniskTidspunkt = nå(clock),
-        søknadsformat = Format.DIGITAL.name,
-        // TODO jah: Dette bør være et eget felt som utledes fra tiltaksperioden og kravfrist.
-        forventetOppstartTidspunkt = behandling.saksopplysningsperiode?.fraOgMed,
-        sakYtelse = "IND",
-        behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-        behandlingStatus = BehandlingStatus.UNDER_BEHANDLING,
-        behandlingResultat = null,
-        resultatBegrunnelse = null,
-        behandlingMetode = BehandlingMetode.MANUELL.name,
-        // skal være -5 for kode 6
-        opprettetAv = if (gjelderKode6) "-5" else "system",
-        saksbehandler = if (gjelderKode6) "-5" else behandling.saksbehandler,
-        ansvarligBeslutter = if (gjelderKode6) "-5" else null,
-
-        tilbakekrevingsbeløp = null,
-        funksjonellPeriodeFom = null,
-        funksjonellPeriodeTom = null,
-        avsender = "tiltakspenger-saksbehandling-api",
-        versjon = versjon,
-        hendelse = "opprettet_behandling",
-        behandlingAarsak = BehandlingAarsak.SOKNAD,
-    )
-}
 
 fun genererSaksstatistikkForRammevedtak(
     vedtak: Rammevedtak,
@@ -75,7 +33,6 @@ fun genererSaksstatistikkForRammevedtak(
         søknadsformat = Format.DIGITAL.name,
         // TODO jah: Hva gjør vi ved revurdering/stans i dette tilfellet. Skal vi sende førstegangsbehandling sin første innvilget fraOgMed eller null?
         forventetOppstartTidspunkt = if (behandling.erFørstegangsbehandling) behandling.saksopplysningsperiode?.fraOgMed else null,
-        sakYtelse = "IND",
         behandlingType = if (behandling.erFørstegangsbehandling) BehandlingType.FØRSTEGANGSBEHANDLING else BehandlingType.REVURDERING,
         // TODO jah: I følge confluence-dokken så finner jeg ikke dette feltet. Burde det heller vært AVSLUTTET?
         behandlingStatus = BehandlingStatus.FERDIG_BEHANDLET,
@@ -85,7 +42,6 @@ fun genererSaksstatistikkForRammevedtak(
         },
         // TODO jah: Denne bør ikke være null.
         resultatBegrunnelse = null,
-        behandlingMetode = BehandlingMetode.MANUELL.name,
 
         // skal være -5 for kode 6
         opprettetAv = if (gjelderKode6) "-5" else "system",
@@ -95,9 +51,52 @@ fun genererSaksstatistikkForRammevedtak(
         tilbakekrevingsbeløp = null,
         funksjonellPeriodeFom = null,
         funksjonellPeriodeTom = null,
-        avsender = "tiltakspenger-saksbehandling-api",
         versjon = versjon,
         hendelse = "iverksatt_behandling",
+        behandlingAarsak = behandling.getBehandlingAarsak(),
+    )
+}
+
+fun genererSaksstatistikkForBehandling(
+    behandling: Behandling,
+    gjelderKode6: Boolean,
+    versjon: String,
+    clock: Clock,
+    hendelse: String,
+): StatistikkSakDTO {
+    return StatistikkSakDTO(
+        sakId = behandling.sakId.toString(),
+        saksnummer = behandling.saksnummer.toString(),
+        behandlingId = behandling.id.toString(),
+        relatertBehandlingId = null,
+        fnr = behandling.fnr.verdi,
+        mottattTidspunkt = if (behandling.erFørstegangsbehandling) behandling.søknad!!.opprettet else behandling.opprettet,
+        registrertTidspunkt = behandling.opprettet,
+        ferdigBehandletTidspunkt = null,
+        vedtakTidspunkt = null,
+        endretTidspunkt = nå(clock),
+        utbetaltTidspunkt = null,
+        tekniskTidspunkt = nå(clock),
+        søknadsformat = Format.DIGITAL.name,
+        forventetOppstartTidspunkt = if (behandling.erFørstegangsbehandling) behandling.saksopplysningsperiode?.fraOgMed else null,
+        behandlingType = if (behandling.erFørstegangsbehandling) BehandlingType.FØRSTEGANGSBEHANDLING else BehandlingType.REVURDERING,
+        behandlingStatus = if (behandling.status == Behandlingsstatus.KLAR_TIL_BESLUTNING || behandling.status == Behandlingsstatus.UNDER_BESLUTNING) {
+            BehandlingStatus.UNDER_BESLUTNING
+        } else {
+            BehandlingStatus.UNDER_BEHANDLING
+        },
+        behandlingResultat = null,
+        resultatBegrunnelse = null,
+        // skal være -5 for kode 6
+        opprettetAv = if (gjelderKode6) "-5" else "system",
+        saksbehandler = if (gjelderKode6) "-5" else behandling.saksbehandler,
+        ansvarligBeslutter = if (gjelderKode6) "-5" else behandling.beslutter,
+
+        tilbakekrevingsbeløp = null,
+        funksjonellPeriodeFom = null,
+        funksjonellPeriodeTom = null,
+        versjon = versjon,
+        hendelse = hendelse,
         behandlingAarsak = behandling.getBehandlingAarsak(),
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakRepoImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakRepoImpl.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.sak
+package no.nav.tiltakspenger.saksbehandling.statistikk.behandling
 
 import kotliquery.Row
 import kotliquery.TransactionalSession
@@ -8,11 +8,6 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.BehandlingAarsak
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.BehandlingResultat
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.BehandlingStatus
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.BehandlingType
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.StatistikkSakDTO
 import org.intellij.lang.annotations.Language
 
 /**

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/behandling/StatistikkSakService.kt
@@ -1,0 +1,106 @@
+package no.nav.tiltakspenger.saksbehandling.statistikk.behandling
+
+import arrow.core.getOrElse
+import no.nav.tiltakspenger.libs.common.BehandlingId
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.SøknadId
+import no.nav.tiltakspenger.libs.person.AdressebeskyttelseGradering
+import no.nav.tiltakspenger.libs.person.harStrengtFortroligAdresse
+import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Behandling
+import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtak
+import java.time.Clock
+
+class StatistikkSakService(
+    private val tilgangsstyringService: TilgangsstyringService,
+    private val gitHash: String,
+    private val clock: Clock,
+) {
+    suspend fun genererStatistikkForNyForstegangsbehandling(
+        behandling: Behandling,
+        søknadId: SøknadId,
+    ): StatistikkSakDTO {
+        require(behandling.erFørstegangsbehandling)
+        return genererSaksstatistikkForBehandling(
+            behandling = behandling,
+            gjelderKode6 = gjelderKode6(behandling.fnr, "SøknadId: $søknadId"),
+            versjon = gitHash,
+            clock = clock,
+            hendelse = "opprettet_behandling",
+        )
+    }
+
+    suspend fun genererStatistikkForRevurdering(
+        behandling: Behandling,
+    ): StatistikkSakDTO {
+        require(behandling.erRevurdering)
+        return genererSaksstatistikkForBehandling(
+            behandling = behandling,
+            gjelderKode6 = gjelderKode6(behandling.fnr, "BehandlingId: ${behandling.id}"),
+            versjon = gitHash,
+            clock = clock,
+            hendelse = "opprettet_revurdering",
+        )
+    }
+
+    suspend fun genererStatistikkForRammevedtak(
+        rammevedtak: Rammevedtak,
+        behandlingId: BehandlingId,
+    ): StatistikkSakDTO {
+        return genererSaksstatistikkForRammevedtak(
+            vedtak = rammevedtak,
+            gjelderKode6 = gjelderKode6(rammevedtak.fnr, "BehandlingId: $behandlingId"),
+            versjon = gitHash,
+            clock = clock,
+        )
+    }
+
+    suspend fun genererStatistikkForSendTilBeslutter(
+        behandling: Behandling,
+    ): StatistikkSakDTO {
+        return genererSaksstatistikkForBehandling(
+            behandling = behandling,
+            gjelderKode6 = gjelderKode6(behandling.fnr, "BehandlingId: ${behandling.id}"),
+            versjon = gitHash,
+            clock = clock,
+            hendelse = "sendt_til_beslutter",
+        )
+    }
+
+    suspend fun genererStatistikkForUnderkjennBehandling(
+        behandling: Behandling,
+    ): StatistikkSakDTO {
+        return genererSaksstatistikkForBehandling(
+            behandling = behandling,
+            gjelderKode6 = gjelderKode6(behandling.fnr, "BehandlingId: ${behandling.id}"),
+            versjon = gitHash,
+            clock = clock,
+            hendelse = "underkjent_behandling",
+        )
+    }
+
+    suspend fun genererStatistikkForOppdatertSaksbehandlerEllerBeslutter(
+        behandling: Behandling,
+    ): StatistikkSakDTO {
+        return genererSaksstatistikkForBehandling(
+            behandling = behandling,
+            gjelderKode6 = gjelderKode6(behandling.fnr, "BehandlingId: ${behandling.id}"),
+            versjon = gitHash,
+            clock = clock,
+            hendelse = "oppdatert_saksbehandler_beslutter",
+        )
+    }
+
+    private suspend fun gjelderKode6(fnr: Fnr, sporingsinformasjon: String): Boolean {
+        val adressebeskyttelseGradering: List<AdressebeskyttelseGradering>? =
+            tilgangsstyringService.adressebeskyttelseEnkel(fnr)
+                .getOrElse {
+                    throw IllegalArgumentException(
+                        "Kunne ikke hente adressebeskyttelsegradering for person. $sporingsinformasjon",
+                    )
+                }
+        require(adressebeskyttelseGradering != null) { "Fant ikke adressebeskyttelse for person. $sporingsinformasjon" }
+
+        return adressebeskyttelseGradering.harStrengtFortroligAdresse()
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad
+package no.nav.tiltakspenger.saksbehandling.statistikk.vedtak
 
 import java.time.LocalDate
 import java.util.UUID

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadMapper.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadMapper.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad
+package no.nav.tiltakspenger.saksbehandling.statistikk.vedtak
 
 import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtak
 import java.util.UUID

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkStønadPostgresRepo.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.stønad
+package no.nav.tiltakspenger.saksbehandling.statistikk.vedtak
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotliquery.Row
@@ -11,8 +11,6 @@ import no.nav.tiltakspenger.libs.json.objectMapper
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.libs.persistering.infrastruktur.PostgresSessionFactory
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkStønadDTO
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkUtbetalingDTO
 import no.nav.tiltakspenger.saksbehandling.infra.repo.toPGObject
 import org.intellij.lang.annotations.Language
 import java.time.Clock

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkUtbetalingDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/statistikk/vedtak/StatistikkUtbetalingDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad
+package no.nav.tiltakspenger.saksbehandling.statistikk.vedtak
 
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsvedtak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsvedtak.kt
@@ -7,13 +7,13 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.VedtakId
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.periodisering.Periode
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkUtbetalingDTO
 import no.nav.tiltakspenger.saksbehandling.journalføring.JournalpostId
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandletAutomatisk
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.Meldeperiode
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
 import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkUtbetalingDTO
 import java.time.Clock
 import java.time.LocalDateTime
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/LocalApplicationContext.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/LocalApplicationContext.kt
@@ -213,7 +213,6 @@ class LocalApplicationContext(
             meldeperiodeRepo = meldekortContext.meldeperiodeRepo,
             statistikkSakRepo = statistikkContext.statistikkSakRepo,
             statistikkStønadRepo = statistikkContext.statistikkStønadRepo,
-            gitHash = "fake-git-hash",
             journalførVedtaksbrevGateway = journalførFakeVedtaksbrevGateway,
             genererVedtaksbrevGateway = genererInnvilgelsevedtaksbrevGateway,
             genererStansvedtaksbrevGateway = genererStansvedtaksbrevGateway,
@@ -225,6 +224,7 @@ class LocalApplicationContext(
             tiltaksdeltagelseGateway = tiltakGatewayFake,
             oppgaveGateway = oppgaveGateway,
             clock = clock,
+            statistikkSakService = statistikkContext.statistikkSakService,
         ) {}
     }
     override val utbetalingContext by lazy {

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/common/TestApplicationContext.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/common/TestApplicationContext.kt
@@ -165,7 +165,7 @@ class TestApplicationContext(
     }
 
     override val statistikkContext by lazy {
-        object : StatistikkContext(sessionFactory, clock) {
+        object : StatistikkContext(sessionFactory, tilgangsstyringFakeGateway, gitHash, clock) {
             override val statistikkStønadRepo = statistikkStønadFakeRepo
             override val statistikkSakRepo = statistikkSakFakeRepo
         }
@@ -225,7 +225,6 @@ class TestApplicationContext(
             meldeperiodeRepo = meldeperiodeFakeRepo,
             statistikkSakRepo = statistikkSakFakeRepo,
             statistikkStønadRepo = statistikkStønadFakeRepo,
-            gitHash = "fake-git-hash",
             journalførVedtaksbrevGateway = journalførFakeVedtaksbrevGateway,
             genererVedtaksbrevGateway = genererFakeVedtaksbrevGateway,
             genererStansvedtaksbrevGateway = genererFakeVedtaksbrevGateway,
@@ -237,6 +236,7 @@ class TestApplicationContext(
             tiltaksdeltagelseGateway = tiltakGatewayFake,
             oppgaveGateway = oppgaveGateway,
             clock = clock,
+            statistikkSakService = statistikkContext.statistikkSakService,
         ) {
             override val rammevedtakRepo = rammevedtakFakeRepo
             override val behandlingRepo = behandlingFakeRepo

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkSakFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkSakFakeRepo.kt
@@ -5,7 +5,7 @@ import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.StatistikkSakDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakDTO
 
 class StatistikkSakFakeRepo : StatistikkSakRepo {
     private val data = Atomic(mutableMapOf<SakId, StatistikkSakDTO>())

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkStønadFakeRepo.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/fakes/repos/StatistikkStønadFakeRepo.kt
@@ -5,8 +5,8 @@ import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.persistering.domene.TransactionContext
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkStønadDTO
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.StatistikkUtbetalingDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkStønadDTO
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkUtbetalingDTO
 
 class StatistikkStønadFakeRepo : StatistikkStønadRepo {
 

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/infra/repo/TestDataHelper.kt
@@ -13,8 +13,8 @@ import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.Identhende
 import no.nav.tiltakspenger.saksbehandling.person.infra.repo.PersonPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.repo.PersonhendelseRepository
 import no.nav.tiltakspenger.saksbehandling.sak.infra.repo.SakPostgresRepo
-import no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.sak.StatistikkSakRepoImpl
-import no.nav.tiltakspenger.saksbehandling.statistikk.infra.repo.stønad.StatistikkStønadPostgresRepo
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakRepoImpl
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.StatistikkStønadPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.søknad.infra.repo.PostgresSøknadRepo
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltagelse.infra.kafka.repository.TiltaksdeltakerKafkaRepository
 import no.nav.tiltakspenger.saksbehandling.utbetaling.infra.repo.UtbetalingsvedtakPostgresRepo

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/identhendelser/jobb/IdenthendelseJobbTest.kt
@@ -14,8 +14,6 @@ import no.nav.tiltakspenger.libs.common.random
 import no.nav.tiltakspenger.libs.json.objectMapper
 import no.nav.tiltakspenger.libs.kafka.Producer
 import no.nav.tiltakspenger.libs.periodisering.zoneIdOslo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.genererSaksstatistikkForRammevedtak
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.stønad.genererStønadsstatistikkForRammevedtak
 import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterIverksattFørstegangsbehandling
 import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterSakOgSøknad
 import no.nav.tiltakspenger.saksbehandling.infra.repo.withMigratedDb
@@ -25,6 +23,8 @@ import no.nav.tiltakspenger.saksbehandling.person.identhendelser.Personident
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseDto
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.kafka.IdenthendelseKafkaProducer
 import no.nav.tiltakspenger.saksbehandling.person.identhendelser.repo.IdenthendelseDb
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.genererSaksstatistikkForRammevedtak
+import no.nav.tiltakspenger.saksbehandling.statistikk.vedtak.genererStønadsstatistikkForRammevedtak
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/personhendelser/PersonhendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/person/personhendelser/PersonhendelseServiceTest.kt
@@ -15,7 +15,6 @@ import no.nav.person.pdl.leesah.forelderbarnrelasjon.ForelderBarnRelasjon
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.random
 import no.nav.tiltakspenger.libs.periodisering.zoneIdOslo
-import no.nav.tiltakspenger.saksbehandling.behandling.service.statistikk.sak.genererStatistikkForNyFørstegangsbehandling
 import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterOpprettetFørstegangsbehandling
 import no.nav.tiltakspenger.saksbehandling.infra.repo.persisterSakOgSøknad
 import no.nav.tiltakspenger.saksbehandling.infra.repo.withMigratedDb
@@ -24,6 +23,7 @@ import no.nav.tiltakspenger.saksbehandling.person.EnkelPerson
 import no.nav.tiltakspenger.saksbehandling.person.PersonGateway
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.kafka.Opplysningstype
 import no.nav.tiltakspenger.saksbehandling.person.personhendelser.repo.PersonhendelseType
+import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.genererSaksstatistikkForBehandling
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -195,11 +195,12 @@ class PersonhendelseServiceTest {
                     ),
                 )
                 statistikkSakRepo.lagre(
-                    genererStatistikkForNyFørstegangsbehandling(
+                    genererSaksstatistikkForBehandling(
                         behandling = behandling,
                         gjelderKode6 = false,
                         versjon = "1",
                         clock = Clock.system(zoneIdOslo),
+                        hendelse = "opprettet_behandling",
                     ),
                 )
                 val personhendelse = getPersonhendelse(
@@ -249,11 +250,12 @@ class PersonhendelseServiceTest {
                     ),
                 )
                 statistikkSakRepo.lagre(
-                    genererStatistikkForNyFørstegangsbehandling(
+                    genererSaksstatistikkForBehandling(
                         behandling = behandling,
                         gjelderKode6 = false,
                         versjon = "1",
                         clock = Clock.system(zoneIdOslo),
+                        hendelse = "opprettet_behandling",
                     ),
                 )
                 val personhendelse = getPersonhendelse(


### PR DESCRIPTION
DVH ønsker informasjon om behandlingen av saken, inkludert når saken sendes til beslutter, underkjennes, endrer saksbehandler/beslutter osv. Jeg har lagt til dette, samt innført en ny statistikk-status for sakene som er under beslutning. Vi manglet også statistikk for oppretting av revurdering. 

https://trello.com/c/qQ7idKtU/1078-sende-statistikk-n%C3%A5r-vi-sender-f%C3%B8rstegangsvedtak-til-beslutter