### PR TITLE
Avslutt meldekortbehandling

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/Behandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/domene/Behandling.kt
@@ -73,7 +73,7 @@ data class Behandling(
 ) {
     val erAvsluttet: Boolean by lazy { status == AVBRUTT || status == VEDTATT }
     val erUnderBehandling: Boolean = status == UNDER_BEHANDLING
-    val erAvbrutt: Boolean by lazy { status == AVBRUTT }
+    val erAvbrutt: Boolean = status == AVBRUTT
 
     val erVedtatt: Boolean = status == VEDTATT
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/AvbruttDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/AvbruttDTO.kt
@@ -2,13 +2,13 @@ package no.nav.tiltakspenger.saksbehandling.infra.route
 
 import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 
-internal data class AvbruttDTO(
+data class AvbruttDTO(
     val avbruttAv: String,
     val avbruttTidspunkt: String,
     val begrunnelse: String,
 )
 
-internal fun Avbrutt.toAvbruttDTO() = AvbruttDTO(
+fun Avbrutt.toAvbruttDTO() = AvbruttDTO(
     avbruttAv = saksbehandler,
     avbruttTidspunkt = tidspunkt.toString(),
     begrunnelse = begrunnelse,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/route/Routes.kt
@@ -60,6 +60,7 @@ fun Route.routes(
         overtaMeldekortBehandlingService = applicationContext.meldekortContext.overtaMeldekortBehandlingService,
         taMeldekortBehandlingService = applicationContext.meldekortContext.taMeldekortBehandlingService,
         leggTilbakeMeldekortBehandlingService = applicationContext.meldekortContext.leggTilbakeMeldekortBehandlingService,
+        avbrytMeldekortBehandlingService = applicationContext.meldekortContext.avbrytMeldekortBehandlingService,
         clock = applicationContext.clock,
     )
     mottaSøknadRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/AvbruttMeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/AvbruttMeldekortBehandling.kt
@@ -1,0 +1,56 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene
+
+import arrow.core.Either
+import no.nav.tiltakspenger.libs.common.Fnr
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
+import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AVBRUTT
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
+import no.nav.tiltakspenger.saksbehandling.sak.Saksnummer
+import java.time.LocalDateTime
+
+data class AvbruttMeldekortBehandling(
+    override val id: MeldekortId,
+    override val sakId: SakId,
+    override val saksnummer: Saksnummer,
+    override val fnr: Fnr,
+    override val opprettet: LocalDateTime,
+    override val dager: MeldekortDager,
+    override val beregning: MeldekortBeregning?,
+    override val meldeperiode: Meldeperiode,
+    override val type: MeldekortBehandlingType,
+    override val brukersMeldekort: BrukersMeldekort?,
+    override val saksbehandler: String?,
+    override val navkontor: Navkontor,
+    override val begrunnelse: MeldekortBehandlingBegrunnelse?,
+    override val attesteringer: Attesteringer,
+    override val ikkeRettTilTiltakspengerTidspunkt: LocalDateTime?,
+    override val avbrutt: Avbrutt?,
+) : MeldekortBehandling {
+    override val iverksattTidspunkt = null
+    override val sendtTilBeslutning = null
+
+    override val status = AVBRUTT
+
+    override val beslutter = null
+
+    override val beløpTotal = beregning?.beregnTotaltBeløp()
+    override val ordinærBeløp = beregning?.beregnTotalOrdinærBeløp()
+    override val barnetilleggBeløp = beregning?.beregnTotalBarnetillegg()
+
+    override fun overta(saksbehandler: Saksbehandler): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
+        throw IllegalStateException("Kan ikke overta avbrutt meldekortbehandling")
+    }
+
+    override fun taMeldekortBehandling(saksbehandler: Saksbehandler): MeldekortBehandling {
+        throw IllegalStateException("Kan ikke tildele avbrutt meldekortbehandling")
+    }
+
+    override fun leggTilbakeMeldekortBehandling(saksbehandler: Saksbehandler): Either<KanIkkeLeggeTilbakeMeldekortBehandling, MeldekortBehandling> {
+        throw IllegalStateException("Kan ikke legge tilbake avbrutt meldekortbehandling")
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KanIkkeAvbryteMeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/KanIkkeAvbryteMeldekortBehandling.kt
@@ -1,0 +1,8 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.domene
+
+sealed interface KanIkkeAvbryteMeldekortBehandling {
+    data object MåVæreSaksbehandlerEllerBeslutter : KanIkkeAvbryteMeldekortBehandling
+    data object MåVæreSaksbehandlerForMeldekortet : KanIkkeAvbryteMeldekortBehandling
+    data object MåVæreUnderBehandling : KanIkkeAvbryteMeldekortBehandling
+    data object MåVæreOpprettetAvSaksbehandler : KanIkkeAvbryteMeldekortBehandling
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletAutomatisk.kt
@@ -10,6 +10,7 @@ import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
+import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.infra.setup.AUTOMATISK_SAKSBEHANDLER_ID
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.overta.KunneIkkeOvertaMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.Navkontor
@@ -45,6 +46,7 @@ data class MeldekortBehandletAutomatisk(
     override val ikkeRettTilTiltakspengerTidspunkt = null
 
     override val attesteringer = Attesteringer.empty()
+    override val avbrutt: Avbrutt? = null
 
     init {
         require(type == MeldekortBehandlingType.FØRSTE_BEHANDLING) {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletManuelt.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandletManuelt.kt
@@ -13,7 +13,9 @@ import no.nav.tiltakspenger.saksbehandling.felles.Attestering
 import no.nav.tiltakspenger.saksbehandling.felles.AttesteringId
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringsstatus
+import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AVBRUTT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
@@ -53,6 +55,7 @@ data class MeldekortBehandletManuelt(
     override val beregning: MeldekortBeregning,
     override val dager: MeldekortDager,
 ) : MeldekortBehandling.Behandlet {
+    override val avbrutt: Avbrutt? = null
 
     init {
         require(meldeperiode.periode.fraOgMed == beregningPeriode.fraOgMed) {
@@ -86,6 +89,8 @@ data class MeldekortBehandletManuelt(
             }
 
             AUTOMATISK_BEHANDLET -> throw IllegalStateException("Et manuelt behandlet meldekort kan ikke ha status AUTOMATISK_BEHANDLET")
+
+            AVBRUTT -> throw IllegalStateException("Et manuelt behandlet meldekort kan ikke ha status AVBRUTT")
         }
     }
 
@@ -176,6 +181,7 @@ data class MeldekortBehandletManuelt(
         saksbehandler: Saksbehandler,
     ): Either<KunneIkkeOvertaMeldekortBehandling, MeldekortBehandling> {
         return when (this.status) {
+            AVBRUTT -> throw IllegalStateException("Et manuelt behandlet meldekort kan ikke ha status AVBRUTT")
             UNDER_BEHANDLING -> throw IllegalStateException("Et utfylt meldekort kan ikke ha status UNDER_BEHANDLING")
             KLAR_TIL_BESLUTNING -> KunneIkkeOvertaMeldekortBehandling.BehandlingenMåVæreUnderBeslutningForÅOverta.left()
             UNDER_BESLUTNING -> {
@@ -220,6 +226,7 @@ data class MeldekortBehandletManuelt(
             GODKJENT,
             AUTOMATISK_BEHANDLET,
             IKKE_RETT_TIL_TILTAKSPENGER,
+            AVBRUTT,
             -> {
                 throw IllegalArgumentException(
                     "Kan ikke ta meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",
@@ -248,6 +255,7 @@ data class MeldekortBehandletManuelt(
             GODKJENT,
             AUTOMATISK_BEHANDLET,
             IKKE_RETT_TIL_TILTAKSPENGER,
+            AVBRUTT,
             -> {
                 throw IllegalArgumentException(
                     "Kan ikke legge tilbake meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandling.kt
@@ -11,7 +11,9 @@ import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.libs.periodisering.Periodisering
 import no.nav.tiltakspenger.libs.tiltak.TiltakstypeSomGirRett
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
+import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AVBRUTT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
@@ -60,18 +62,20 @@ sealed interface MeldekortBehandling {
     /** Denne styres kun av vedtakene. Dersom vi har en åpen meldekortbehandling (inkl. til beslutning) kan et nytt vedtak overstyre hele meldeperioden til [MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER] */
     val ikkeRettTilTiltakspengerTidspunkt: LocalDateTime?
 
-    /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den vil bli erstattet med AVBRUTT senere. */
+    /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den brukes ifm stans. */
     val erAvsluttet
         get() = when (status) {
             UNDER_BEHANDLING, KLAR_TIL_BESLUTNING, UNDER_BESLUTNING -> false
-            GODKJENT, AUTOMATISK_BEHANDLET, IKKE_RETT_TIL_TILTAKSPENGER -> true
+            GODKJENT, AUTOMATISK_BEHANDLET, IKKE_RETT_TIL_TILTAKSPENGER, AVBRUTT -> true
         }
 
     val beløpTotal: Int?
     val ordinærBeløp: Int?
     val barnetilleggBeløp: Int?
 
-    /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den vil bli erstattet med AVBRUTT senere. */
+    val avbrutt: Avbrutt?
+
+    /** Merk at statusen [IKKE_RETT_TIL_TILTAKSPENGER] anses som avsluttet. Den brukes ifm stans. */
     fun erÅpen(): Boolean = !erAvsluttet
 
     /** Oppdaterer meldeperioden til [meldeperiode] dersom den har samme kjede id, den er nyere enn den eksisterende og dette ikke er avsluttet meldekortbehandling. */
@@ -99,7 +103,9 @@ sealed interface MeldekortBehandling {
                 beregning = null,
             )
 
-            is MeldekortBehandletAutomatisk -> null
+            is MeldekortBehandletAutomatisk,
+            is AvbruttMeldekortBehandling,
+            -> null
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlingStatus.kt
@@ -7,4 +7,5 @@ enum class MeldekortBehandlingStatus {
     GODKJENT,
     AUTOMATISK_BEHANDLET,
     IKKE_RETT_TIL_TILTAKSPENGER,
+    AVBRUTT,
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -229,10 +229,6 @@ data class MeldekortUnderBehandling(
             return KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerForMeldekortet.left()
         }
 
-        require(this.brukersMeldekort == null) {
-            return KanIkkeAvbryteMeldekortBehandling.MåVæreOpprettetAvSaksbehandler.left()
-        }
-
         return AvbruttMeldekortBehandling(
             id = id,
             sakId = sakId,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -214,6 +214,49 @@ data class MeldekortUnderBehandling(
         }
     }
 
+    fun avbryt(
+        avbruttAv: Saksbehandler,
+        begrunnelse: String,
+        tidspunkt: LocalDateTime,
+    ): Either<KanIkkeAvbryteMeldekortBehandling, MeldekortBehandling> {
+        require(avbruttAv.erSaksbehandlerEllerBeslutter()) {
+            return KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerEllerBeslutter.left()
+        }
+        require(this.status == UNDER_BEHANDLING) {
+            return KanIkkeAvbryteMeldekortBehandling.MåVæreUnderBehandling.left()
+        }
+        require(this.saksbehandler == null || this.saksbehandler == avbruttAv.navIdent) {
+            return KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerForMeldekortet.left()
+        }
+
+        require(this.brukersMeldekort == null) {
+            return KanIkkeAvbryteMeldekortBehandling.MåVæreOpprettetAvSaksbehandler.left()
+        }
+
+        return AvbruttMeldekortBehandling(
+            id = id,
+            sakId = sakId,
+            saksnummer = saksnummer,
+            fnr = fnr,
+            opprettet = opprettet,
+            beregning = beregning,
+            saksbehandler = avbruttAv.navIdent,
+            navkontor = navkontor,
+            ikkeRettTilTiltakspengerTidspunkt = ikkeRettTilTiltakspengerTidspunkt,
+            brukersMeldekort = brukersMeldekort,
+            meldeperiode = meldeperiode,
+            type = type,
+            begrunnelse = this.begrunnelse,
+            attesteringer = attesteringer,
+            dager = dager,
+            avbrutt = Avbrutt(
+                tidspunkt = tidspunkt,
+                saksbehandler = avbruttAv.navIdent,
+                begrunnelse = begrunnelse,
+            ),
+        ).right()
+    }
+
     init {
         if (status == IKKE_RETT_TIL_TILTAKSPENGER) {
             require(dager.all { it.status == MeldekortDagStatus.SPERRET })

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -11,7 +11,9 @@ import no.nav.tiltakspenger.libs.common.Saksbehandler
 import no.nav.tiltakspenger.libs.common.nå
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.saksbehandling.felles.Attesteringer
+import no.nav.tiltakspenger.saksbehandling.felles.Avbrutt
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.AVBRUTT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.GODKJENT
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING
@@ -43,6 +45,7 @@ data class MeldekortUnderBehandling(
     override val dager: MeldekortDager,
     override val beregning: MeldekortBeregning?,
 ) : MeldekortBehandling {
+    override val avbrutt: Avbrutt? = null
     override val iverksattTidspunkt = null
 
     override val status =
@@ -152,6 +155,7 @@ data class MeldekortUnderBehandling(
             GODKJENT,
             IKKE_RETT_TIL_TILTAKSPENGER,
             AUTOMATISK_BEHANDLET,
+            AVBRUTT,
             -> throw IllegalStateException("Kan ikke overta meldekortbehandling med status ${this.status}")
         }
     }
@@ -173,6 +177,7 @@ data class MeldekortUnderBehandling(
             GODKJENT,
             AUTOMATISK_BEHANDLET,
             IKKE_RETT_TIL_TILTAKSPENGER,
+            AVBRUTT,
             -> {
                 throw IllegalArgumentException(
                     "Kan ikke ta meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",
@@ -200,6 +205,7 @@ data class MeldekortUnderBehandling(
             GODKJENT,
             AUTOMATISK_BEHANDLET,
             IKKE_RETT_TIL_TILTAKSPENGER,
+            AVBRUTT,
             -> {
                 throw IllegalArgumentException(
                     "Kan ikke ta meldekortbehandling når behandlingen har status ${this.status}. Utøvende saksbehandler: $saksbehandler. Saksbehandler på behandling: ${this.saksbehandler}",

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingPostgresRepo.kt
@@ -16,6 +16,9 @@ import no.nav.tiltakspenger.libs.persistering.infrastruktur.sqlQuery
 import no.nav.tiltakspenger.saksbehandling.behandling.infra.repo.attesteringer.toAttesteringer
 import no.nav.tiltakspenger.saksbehandling.behandling.infra.repo.attesteringer.toDbJson
 import no.nav.tiltakspenger.saksbehandling.felles.toAttesteringer
+import no.nav.tiltakspenger.saksbehandling.infra.repo.dto.toAvbrutt
+import no.nav.tiltakspenger.saksbehandling.infra.repo.dto.toDbJson
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.AvbruttMeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandletAutomatisk
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandletManuelt
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
@@ -59,7 +62,8 @@ class MeldekortBehandlingPostgresRepo(
                         type,
                         begrunnelse,
                         attesteringer,
-                        brukers_meldekort_id
+                        brukers_meldekort_id,
+                        avbrutt
                     ) values (
                         :id,
                         :meldeperiode_kjede_id,
@@ -80,7 +84,8 @@ class MeldekortBehandlingPostgresRepo(
                         :type,
                         :begrunnelse,
                         to_jsonb(:attesteringer::jsonb),
-                        :brukers_meldekort_id
+                        :brukers_meldekort_id,
+                        to_jsonb(:avbrutt::jsonb)
                     )
                     """,
                     "id" to meldekortBehandling.id.toString(),
@@ -103,6 +108,7 @@ class MeldekortBehandlingPostgresRepo(
                     "begrunnelse" to meldekortBehandling.begrunnelse?.verdi,
                     "attesteringer" to meldekortBehandling.attesteringer.toDbJson(),
                     "brukers_meldekort_id" to meldekortBehandling.brukersMeldekort?.id?.toString(),
+                    "avbrutt" to meldekortBehandling.avbrutt?.toDbJson(),
                 ).asUpdate,
             )
         }
@@ -127,7 +133,8 @@ class MeldekortBehandlingPostgresRepo(
                         sendt_til_beslutning = :sendt_til_beslutning,
                         meldeperiode_id = :meldeperiode_id,
                         begrunnelse = :begrunnelse,
-                        attesteringer = to_json(:attesteringer::jsonb)
+                        attesteringer = to_json(:attesteringer::jsonb),
+                        avbrutt = to_jsonb(:avbrutt::jsonb)
                     where id = :id
                     """,
                     "id" to meldekortBehandling.id.toString(),
@@ -142,6 +149,7 @@ class MeldekortBehandlingPostgresRepo(
                     "meldeperiode_id" to meldekortBehandling.meldeperiode.id.toString(),
                     "begrunnelse" to meldekortBehandling.begrunnelse?.verdi,
                     "attesteringer" to meldekortBehandling.attesteringer.toDbJson(),
+                    "avbrutt" to meldekortBehandling.avbrutt?.toDbJson(),
                 ).asUpdate,
             )
         }
@@ -429,6 +437,27 @@ class MeldekortBehandlingPostgresRepo(
                         sendtTilBeslutning = row.localDateTimeOrNull("sendt_til_beslutning"),
                         beregning = beregning,
                         dager = dager,
+                    )
+                }
+
+                MeldekortBehandlingStatus.AVBRUTT -> {
+                    AvbruttMeldekortBehandling(
+                        id = id,
+                        sakId = sakId,
+                        saksnummer = saksnummer,
+                        fnr = fnr,
+                        opprettet = opprettet,
+                        navkontor = navkontor,
+                        ikkeRettTilTiltakspengerTidspunkt = ikkeRettTilTiltakspengerTidspunkt,
+                        brukersMeldekort = brukersMeldekort,
+                        meldeperiode = meldeperiode,
+                        saksbehandler = saksbehandler,
+                        type = type,
+                        begrunnelse = begrunnelse,
+                        attesteringer = attesteringer,
+                        beregning = beregning,
+                        dager = dager,
+                        avbrutt = row.stringOrNull("avbrutt")?.toAvbrutt(),
                     )
                 }
             }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/repo/MeldekortBehandlingStatusDb.kt
@@ -14,6 +14,7 @@ private enum class MeldekortBehandlingStatusDb {
     GODKJENT,
     IKKE_RETT_TIL_TILTAKSPENGER,
     AUTOMATISK_BEHANDLET,
+    AVBRUTT,
 }
 
 fun String.toMeldekortBehandlingStatus(): MeldekortBehandlingStatus =
@@ -24,6 +25,7 @@ fun String.toMeldekortBehandlingStatus(): MeldekortBehandlingStatus =
         MeldekortBehandlingStatusDb.GODKJENT -> MeldekortBehandlingStatus.GODKJENT
         MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatusDb.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET
+        MeldekortBehandlingStatusDb.AVBRUTT -> MeldekortBehandlingStatus.AVBRUTT
     }
 
 fun MeldekortBehandlingStatus.toDb(): String =
@@ -34,4 +36,5 @@ fun MeldekortBehandlingStatus.toDb(): String =
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDb.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDb.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatusDb.AUTOMATISK_BEHANDLET
+        MeldekortBehandlingStatus.AVBRUTT -> MeldekortBehandlingStatusDb.AVBRUTT
     }.toString()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRoute.kt
@@ -1,0 +1,112 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import no.nav.tiltakspenger.libs.auth.core.TokenService
+import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.common.CorrelationId
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.common.ErrorJson
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
+import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
+import no.nav.tiltakspenger.saksbehandling.felles.ServiceCommand
+import no.nav.tiltakspenger.saksbehandling.infra.repo.correlationId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withBody
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withMeldekortId
+import no.nav.tiltakspenger.saksbehandling.infra.repo.withSakId
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeAvbryteMeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.UtbetalingsstatusDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto.toMeldekortBehandlingDTO
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.AvbrytMeldekortBehandlingService
+
+private const val AVBRYT_MELDEKORTBEHANDLING_PATH = "/sak/{sakId}/meldekort/{meldekortId}/avbryt"
+
+data class AvbrytMeldekortbehandlingBody(
+    val begrunnelse: String,
+)
+
+fun Route.avbrytMeldekortBehandlingRoute(
+    tokenService: TokenService,
+    auditService: AuditService,
+    avbrytMeldekortBehandlingService: AvbrytMeldekortBehandlingService,
+) {
+    val logger = KotlinLogging.logger {}
+    post(AVBRYT_MELDEKORTBEHANDLING_PATH) {
+        logger.debug { "Mottatt post-request på '$AVBRYT_MELDEKORTBEHANDLING_PATH' - avbryter meldekortbehandlingen." }
+        call.withSaksbehandler(tokenService = tokenService, svarMed403HvisIngenScopes = false) { saksbehandler ->
+            call.withSakId { sakId ->
+                call.withMeldekortId { meldekortId ->
+                    call.withBody<AvbrytMeldekortbehandlingBody> { body ->
+                        val correlationId = call.correlationId()
+
+                        avbrytMeldekortBehandlingService.avbryt(
+                            AvbrytMeldekortBehandlingCommand(
+                                sakId = sakId,
+                                meldekortId = meldekortId,
+                                saksbehandler = saksbehandler,
+                                correlationId = correlationId,
+                                begrunnelse = body.begrunnelse,
+                            ),
+                        ).fold(
+                            {
+                                val (status, error) = it.tilStatusOgErrorJson()
+                                call.respond(status, error)
+                            },
+                            {
+                                auditService.logMedMeldekortId(
+                                    meldekortId = meldekortId,
+                                    navIdent = saksbehandler.navIdent,
+                                    action = AuditLogEvent.Action.UPDATE,
+                                    contextMessage = "Saksbehandler avbryter meldekortbehandlingen",
+                                    correlationId = correlationId,
+                                )
+
+                                call.respond(
+                                    status = HttpStatusCode.OK,
+                                    it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.IKKE_GODKJENT),
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun KanIkkeAvbryteMeldekortBehandling.tilStatusOgErrorJson(): Pair<HttpStatusCode, ErrorJson> {
+    return when (this) {
+        KanIkkeAvbryteMeldekortBehandling.MåVæreOpprettetAvSaksbehandler -> HttpStatusCode.BadRequest to ErrorJson(
+            "Meldekortbehandlingen må være opprettet av saksbehandler for å kunne avbrytes",
+            "behandlingen_opprettet_av_saksbehandler",
+        )
+
+        KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerEllerBeslutter -> HttpStatusCode.BadRequest to ErrorJson(
+            "Du må være saksbehandler eller beslutter for å kunne avbryte meldekortbehandlingen",
+            "må_være_saksbehandler_eller_beslutter",
+        )
+
+        KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerForMeldekortet -> HttpStatusCode.BadRequest to ErrorJson(
+            "Meldekortbehandlingen er tildelt en annen saksbehandler",
+            "behandlingen_tildelt_annen_saksbehandler",
+        )
+
+        KanIkkeAvbryteMeldekortBehandling.MåVæreUnderBehandling -> HttpStatusCode.BadRequest to ErrorJson(
+            "Meldekortbehandlingen må være under behandling for å kunne avbrytes",
+            "behandlingen_ikke_under_behandling",
+        )
+    }
+}
+
+data class AvbrytMeldekortBehandlingCommand(
+    val sakId: SakId,
+    val meldekortId: MeldekortId,
+    val begrunnelse: String,
+    override val saksbehandler: Saksbehandler,
+    override val correlationId: CorrelationId,
+) : ServiceCommand

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/MeldekortRoutes.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.behandling.service.sak.SakService
 import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.frameldekortapi.mottaMeldekortRoutes
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.AvbrytMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.IverksettMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.MottaBrukerutfyltMeldekortService
@@ -27,6 +28,7 @@ fun Route.meldekortRoutes(
     overtaMeldekortBehandlingService: OvertaMeldekortBehandlingService,
     taMeldekortBehandlingService: TaMeldekortBehandlingService,
     leggTilbakeMeldekortBehandlingService: LeggTilbakeMeldekortBehandlingService,
+    avbrytMeldekortBehandlingService: AvbrytMeldekortBehandlingService,
     clock: Clock,
 ) {
     hentMeldekortRoute(sakService, auditService, tokenService, clock)
@@ -39,4 +41,5 @@ fun Route.meldekortRoutes(
     taMeldekortBehandlingRoute(tokenService, auditService, taMeldekortBehandlingService)
     underkjennMeldekortBehandlingRoute(underkjennMeldekortBehandlingService, auditService, tokenService)
     leggTilbakeMeldekortBehandlingRoute(tokenService, auditService, leggTilbakeMeldekortBehandlingService)
+    avbrytMeldekortBehandlingRoute(tokenService, auditService, avbrytMeldekortBehandlingService)
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingDTO.kt
@@ -3,7 +3,9 @@ package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.dto
 import no.nav.tiltakspenger.libs.periodisering.PeriodeDTO
 import no.nav.tiltakspenger.libs.periodisering.toDTO
 import no.nav.tiltakspenger.saksbehandling.infra.route.AttesteringDTO
+import no.nav.tiltakspenger.saksbehandling.infra.route.AvbruttDTO
 import no.nav.tiltakspenger.saksbehandling.infra.route.toAttesteringDTO
+import no.nav.tiltakspenger.saksbehandling.infra.route.toAvbruttDTO
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
 import no.nav.tiltakspenger.saksbehandling.utbetaling.domene.Utbetalingsvedtak
@@ -28,6 +30,7 @@ data class MeldekortBehandlingDTO(
     val periode: PeriodeDTO,
     val dager: List<MeldekortDagDTO>,
     val beregning: MeldekortBeregningDTO?,
+    val avbrutt: AvbruttDTO?,
 )
 
 fun Utbetalingsvedtak.toMeldekortBehandlingDTO(): MeldekortBehandlingDTO {
@@ -52,6 +55,7 @@ fun Utbetalingsvedtak.toMeldekortBehandlingDTO(): MeldekortBehandlingDTO {
         periode = behandling.beregningPeriode.toDTO(),
         dager = behandling.dager.tilMeldekortDagerDTO(),
         beregning = behandling.beregning.tilMeldekortBeregningDTO(),
+        avbrutt = behandling.avbrutt?.toAvbruttDTO(),
     )
 }
 
@@ -80,5 +84,6 @@ fun MeldekortBehandling.toMeldekortBehandlingDTO(
         periode = this.periode.toDTO(),
         dager = dager.tilMeldekortDagerDTO(),
         beregning = beregning?.tilMeldekortBeregningDTO(),
+        avbrutt = avbrutt?.toAvbruttDTO(),
     )
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldekortBehandlingStatusDTO.kt
@@ -10,6 +10,7 @@ enum class MeldekortBehandlingStatusDTO {
     GODKJENT,
     AUTOMATISK_BEHANDLET,
     IKKE_RETT_TIL_TILTAKSPENGER,
+    AVBRUTT,
 }
 
 fun MeldekortBehandling.toStatusDTO(): MeldekortBehandlingStatusDTO {
@@ -20,5 +21,6 @@ fun MeldekortBehandling.toStatusDTO(): MeldekortBehandlingStatusDTO {
         MeldekortBehandlingStatus.GODKJENT -> MeldekortBehandlingStatusDTO.GODKJENT
         MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldekortBehandlingStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER
         MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldekortBehandlingStatusDTO.AUTOMATISK_BEHANDLET
+        MeldekortBehandlingStatus.AVBRUTT -> MeldekortBehandlingStatusDTO.AVBRUTT
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeStatusDTO.kt
@@ -14,6 +14,7 @@ enum class MeldeperiodeKjedeStatusDTO {
     UNDER_BESLUTNING,
     GODKJENT,
     AUTOMATISK_BEHANDLET,
+    AVBRUTT,
 }
 
 fun Sak.toMeldeperiodeKjedeStatusDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock): MeldeperiodeKjedeStatusDTO {
@@ -25,6 +26,7 @@ fun Sak.toMeldeperiodeKjedeStatusDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock)
             MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER -> MeldeperiodeKjedeStatusDTO.IKKE_RETT_TIL_TILTAKSPENGER
             MeldekortBehandlingStatus.UNDER_BEHANDLING -> MeldeperiodeKjedeStatusDTO.UNDER_BEHANDLING
             MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET -> MeldeperiodeKjedeStatusDTO.AUTOMATISK_BEHANDLET
+            MeldekortBehandlingStatus.AVBRUTT -> MeldeperiodeKjedeStatusDTO.AVBRUTT
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/setup/MeldekortContext.kt
@@ -19,6 +19,7 @@ import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortApiHttpClien
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.AutomatiskMeldekortBehandlingService
+import no.nav.tiltakspenger.saksbehandling.meldekort.service.AvbrytMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.IverksettMeldekortService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.LeggTilbakeMeldekortBehandlingService
 import no.nav.tiltakspenger.saksbehandling.meldekort.service.OppdaterMeldekortService
@@ -158,6 +159,13 @@ open class MeldekortContext(
 
     val leggTilbakeMeldekortBehandlingService by lazy {
         LeggTilbakeMeldekortBehandlingService(
+            tilgangsstyringService = tilgangsstyringService,
+            meldekortBehandlingRepo = meldekortBehandlingRepo,
+        )
+    }
+
+    val avbrytMeldekortBehandlingService by lazy {
+        AvbrytMeldekortBehandlingService(
             tilgangsstyringService = tilgangsstyringService,
             meldekortBehandlingRepo = meldekortBehandlingRepo,
         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/AvbrytMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/AvbrytMeldekortBehandlingService.kt
@@ -1,0 +1,49 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.service
+
+import arrow.core.Either
+import arrow.core.left
+import no.nav.tiltakspenger.libs.personklient.pdl.TilgangsstyringService
+import no.nav.tiltakspenger.saksbehandling.felles.exceptions.TilgangException
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.KanIkkeAvbryteMeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortUnderBehandling
+import no.nav.tiltakspenger.saksbehandling.meldekort.infra.route.AvbrytMeldekortBehandlingCommand
+import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
+import java.time.LocalDateTime
+
+class AvbrytMeldekortBehandlingService(
+    private val tilgangsstyringService: TilgangsstyringService,
+    private val meldekortBehandlingRepo: MeldekortBehandlingRepo,
+) {
+    suspend fun avbryt(command: AvbrytMeldekortBehandlingCommand): Either<KanIkkeAvbryteMeldekortBehandling, MeldekortBehandling> {
+        val meldekortBehandling = meldekortBehandlingRepo.hent(command.meldekortId)
+            ?: throw IllegalStateException("Fant ikke meldekortBehandling for id ${command.meldekortId}")
+        tilgangsstyringService.harTilgangTilPerson(
+            meldekortBehandling.fnr,
+            command.saksbehandler.roller,
+            command.correlationId,
+        )
+            .onLeft {
+                throw TilgangException("Feil ved tilgangssjekk til person ved avbryting av meldekortbehandling. Feilen var $it")
+            }.onRight {
+                if (!it) throw TilgangException("Saksbehandler ${command.saksbehandler.navIdent} har ikke tilgang til person")
+            }
+        if (meldekortBehandling is MeldekortUnderBehandling) {
+            return meldekortBehandling.avbryt(command.saksbehandler, command.begrunnelse, LocalDateTime.now()).onRight {
+                when (it.status) {
+                    MeldekortBehandlingStatus.AVBRUTT -> meldekortBehandlingRepo.oppdater(it)
+                    MeldekortBehandlingStatus.UNDER_BEHANDLING,
+                    MeldekortBehandlingStatus.UNDER_BESLUTNING,
+                    MeldekortBehandlingStatus.KLAR_TIL_BESLUTNING,
+                    MeldekortBehandlingStatus.GODKJENT,
+                    MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
+                    MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET,
+                    -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne overta")
+                }
+            }
+        } else {
+            return KanIkkeAvbryteMeldekortBehandling.MåVæreUnderBehandling.left()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/AvbrytMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/AvbrytMeldekortBehandlingService.kt
@@ -18,7 +18,7 @@ class AvbrytMeldekortBehandlingService(
 ) {
     suspend fun avbryt(command: AvbrytMeldekortBehandlingCommand): Either<KanIkkeAvbryteMeldekortBehandling, MeldekortBehandling> {
         val meldekortBehandling = meldekortBehandlingRepo.hent(command.meldekortId)
-            ?: throw IllegalStateException("Fant ikke meldekortBehandling for id ${command.meldekortId}")
+            ?: return KanIkkeAvbryteMeldekortBehandling.MåVæreOpprettetAvSaksbehandler.left()
         tilgangsstyringService.harTilgangTilPerson(
             meldekortBehandling.fnr,
             command.saksbehandler.roller,
@@ -39,7 +39,7 @@ class AvbrytMeldekortBehandlingService(
                     MeldekortBehandlingStatus.GODKJENT,
                     MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
                     MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET,
-                    -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne overta")
+                    -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne avbryte")
                 }
             }
         } else {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/LeggTilbakeMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/LeggTilbakeMeldekortBehandlingService.kt
@@ -56,6 +56,7 @@ class LeggTilbakeMeldekortBehandlingService(
                 MeldekortBehandlingStatus.GODKJENT,
                 MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
                 MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET,
+                MeldekortBehandlingStatus.AVBRUTT,
                 -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne legge tilbake")
             }
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/TaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/TaMeldekortBehandlingService.kt
@@ -57,6 +57,7 @@ class TaMeldekortBehandlingService(
                 MeldekortBehandlingStatus.GODKJENT,
                 MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
                 MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET,
+                MeldekortBehandlingStatus.AVBRUTT,
                 -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne tildele seg selv")
             }
         }.right()

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/service/overta/OvertaMeldekortBehandlingService.kt
@@ -41,6 +41,7 @@ class OvertaMeldekortBehandlingService(
                 MeldekortBehandlingStatus.GODKJENT,
                 MeldekortBehandlingStatus.IKKE_RETT_TIL_TILTAKSPENGER,
                 MeldekortBehandlingStatus.AUTOMATISK_BEHANDLET,
+                MeldekortBehandlingStatus.AVBRUTT,
                 -> throw IllegalStateException("Meldekortbehandlingen er i en ugyldig status for å kunne overta")
             }
         }

--- a/src/main/resources/db/migration/V82__meldekortbehandling_add_avbrutt.sql
+++ b/src/main/resources/db/migration/V82__meldekortbehandling_add_avbrutt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE meldekortbehandling ADD COLUMN IF NOT EXISTS avbrutt jsonb DEFAULT NULL;

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRouteTest.kt
@@ -1,0 +1,102 @@
+package no.nav.tiltakspenger.saksbehandling.meldekort.infra.route
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLProtocol
+import io.ktor.http.contentType
+import io.ktor.http.path
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.util.url
+import no.nav.tiltakspenger.libs.common.MeldekortId
+import no.nav.tiltakspenger.libs.common.SakId
+import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.ktor.test.common.defaultRequest
+import no.nav.tiltakspenger.saksbehandling.common.TestApplicationContext
+import no.nav.tiltakspenger.saksbehandling.infra.route.routes
+import no.nav.tiltakspenger.saksbehandling.infra.setup.jacksonSerialization
+import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingStatus
+import no.nav.tiltakspenger.saksbehandling.objectmothers.ObjectMother
+import no.nav.tiltakspenger.saksbehandling.routes.RouteBuilder.iverksett
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class AvbrytMeldekortBehandlingRouteTest {
+    @Test
+    fun `saksbehandler kan avbryte meldekortbehandling`() {
+        with(TestApplicationContext()) {
+            val tac = this
+            testApplication {
+                application {
+                    jacksonSerialization()
+                    routing { routes(tac) }
+                }
+                val (sak, _, _) = this.iverksett(tac)
+                val saksbehandlerIdent = "Z12345"
+                val saksbehandler = ObjectMother.saksbehandler(navIdent = saksbehandlerIdent)
+                val meldekortBehandling = ObjectMother.meldekortUnderBehandling(
+                    sakId = sak.id,
+                    saksnummer = sak.saksnummer,
+                    fnr = sak.fnr,
+                    saksbehandler = saksbehandlerIdent,
+                    status = MeldekortBehandlingStatus.UNDER_BEHANDLING,
+                )
+
+                tac.meldekortContext.meldekortBehandlingRepo.lagre(meldekortBehandling)
+
+                val begrunnelse = "begrunnelse"
+
+                avbrytMeldekortBehandling(
+                    tac,
+                    meldekortBehandling.sakId,
+                    meldekortBehandling.id,
+                    begrunnelse,
+                    saksbehandler,
+                ).also {
+                    val oppdatertMeldekortbehandling =
+                        tac.meldekortContext.meldekortBehandlingRepo.hent(meldekortBehandling.id)
+                    oppdatertMeldekortbehandling shouldNotBe null
+                    oppdatertMeldekortbehandling?.status shouldBe MeldekortBehandlingStatus.AVBRUTT
+                    oppdatertMeldekortbehandling?.avbrutt?.saksbehandler shouldBe saksbehandlerIdent
+                    oppdatertMeldekortbehandling?.avbrutt?.tidspunkt?.toLocalDate() shouldBe LocalDate.now()
+                    oppdatertMeldekortbehandling?.avbrutt?.begrunnelse shouldBe begrunnelse
+                }
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.avbrytMeldekortBehandling(
+        tac: TestApplicationContext,
+        sakId: SakId,
+        meldekortId: MeldekortId,
+        begrunnelse: String,
+        saksbehandler: Saksbehandler = ObjectMother.saksbehandler(),
+    ): String {
+        defaultRequest(
+            HttpMethod.Post,
+            url {
+                protocol = URLProtocol.HTTPS
+                path("/sak/$sakId/meldekort/$meldekortId/avbryt")
+            },
+            jwt = tac.jwtGenerator.createJwtForSaksbehandler(
+                saksbehandler = saksbehandler,
+            ),
+        ) {
+            this.setBody("""{"begrunnelse":"$begrunnelse"}""")
+        }.apply {
+            val bodyAsText = this.bodyAsText()
+            withClue(
+                "Response details:\n" + "Status: ${this.status}\n" + "Content-Type: ${this.contentType()}\n" + "Body: $bodyAsText\n",
+            ) {
+                status shouldBe HttpStatusCode.OK
+            }
+            return bodyAsText
+        }
+    }
+}


### PR DESCRIPTION
Ny status og type for avbrutt meldekortbehandling. Støtte for at saksbehandler skal kunne avbryte behandlingen. 

Noen ting jeg var litt usikker på: 
1. Kan jeg anta at vi ikke har noen MeldekortUnderBehandling hvis saksbehandler ikke har opprettet den? 
2. Er det greit at saksbehandler avbryter behandling som enten er tildelt seg selv eller ikke tildelt? Eller bør vi krever at behandlingen er tildelt for å være sikker på at saksbehandler har opprettet den (ref punkt 1)? 
3. Jeg har lagt inn et krav om at vi ikke kan ha noen meldekort fra bruker når man avbryter behandlingen. Er det riktig? 

https://trello.com/c/XU9ti14p/1461-mulig-for-saksbehandler-%C3%A5-avslutte-manuell-meldekortbehandling