### PR TITLE
Avslutt meldekortbehandling apifiks

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
@@ -5,7 +5,6 @@ import arrow.core.NonEmptyList
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
-import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.libs.periodisering.Periodisering
@@ -18,6 +17,7 @@ import java.time.LocalDate
  * Består av ingen, én eller flere [MeldekortBehandling].
  * Vil være tom fram til første innvilgede førstegangsbehandling.
  * Kun en behandling kan være under behandling (åpen) til enhver tid.
+ * Merk at [verdi] inneholder alle meldekortbehandlinger, inkludert de som er avbrutt, og bør ikke brukes direkte!
  */
 data class MeldekortBehandlinger(
     val verdi: List<MeldekortBehandling>,
@@ -25,8 +25,18 @@ data class MeldekortBehandlinger(
 
     val log = KotlinLogging.logger { }
 
-    val periode: Periode by lazy { Periode(verdi.first().fraOgMed, verdi.last().tilOgMed) }
-    val sakId: SakId by lazy { verdi.first().sakId }
+    val ikkeAvbrutteMeldekortBehandlinger: List<MeldekortBehandling> by lazy {
+        verdi.filter { it !is AvbruttMeldekortBehandling }
+    }
+
+    val avbrutteMeldekortBehandlinger: List<AvbruttMeldekortBehandling> by lazy {
+        verdi.filterIsInstance<AvbruttMeldekortBehandling>()
+    }
+
+    val periode: Periode by lazy {
+        Periode(ikkeAvbrutteMeldekortBehandlinger.first().fraOgMed, ikkeAvbrutteMeldekortBehandlinger.last().tilOgMed)
+    }
+    val sakId: SakId by lazy { ikkeAvbrutteMeldekortBehandlinger.first().sakId }
 
     val meldeperiodeBeregninger by lazy { MeldeperiodeBeregninger(this) }
 
@@ -108,13 +118,12 @@ data class MeldekortBehandlinger(
     }
 
     /** Flere behandlinger kan være knyttet til samme versjon av meldeperioden. */
-    fun hentMeldekortBehandlingerForMeldeperiode(id: MeldeperiodeId): List<MeldekortBehandling> {
-        return this.filter { it.meldeperiode.id == id }
+    fun hentMeldekortBehandlingerForKjede(kjedeId: MeldeperiodeKjedeId): List<MeldekortBehandling> {
+        return ikkeAvbrutteMeldekortBehandlinger.filter { it.kjedeId == kjedeId }
     }
 
-    /** Flere behandlinger kan være knyttet til samme versjon av meldeperioden. */
-    fun hentMeldekortBehandlingerForKjede(kjedeId: MeldeperiodeKjedeId): List<MeldekortBehandling> {
-        return verdi.filter { it.kjedeId == kjedeId }
+    fun hentAvbrutteMeldekortBehandlingerForKjede(kjedeId: MeldeperiodeKjedeId): List<MeldekortBehandling> {
+        return avbrutteMeldekortBehandlinger.filter { it.kjedeId == kjedeId }
     }
 
     fun hentSisteMeldekortBehandlingForKjede(kjedeId: MeldeperiodeKjedeId): MeldekortBehandling? {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortBehandlinger.kt
@@ -4,9 +4,7 @@ import arrow.core.Either
 import arrow.core.NonEmptyList
 import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.tiltakspenger.libs.common.MeldekortId
-import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
-import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.libs.periodisering.Periodisering
 import no.nav.tiltakspenger.libs.tiltak.TiltakstypeSomGirRett
 import no.nav.tiltakspenger.saksbehandling.felles.singleOrNullOrThrow
@@ -32,11 +30,6 @@ data class MeldekortBehandlinger(
     val avbrutteMeldekortBehandlinger: List<AvbruttMeldekortBehandling> by lazy {
         verdi.filterIsInstance<AvbruttMeldekortBehandling>()
     }
-
-    val periode: Periode by lazy {
-        Periode(ikkeAvbrutteMeldekortBehandlinger.first().fraOgMed, ikkeAvbrutteMeldekortBehandlinger.last().tilOgMed)
-    }
-    val sakId: SakId by lazy { ikkeAvbrutteMeldekortBehandlinger.first().sakId }
 
     val meldeperiodeBeregninger by lazy { MeldeperiodeBeregninger(this) }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/domene/MeldekortUnderBehandling.kt
@@ -255,7 +255,7 @@ data class MeldekortUnderBehandling(
         require(this.status == UNDER_BEHANDLING) {
             return KanIkkeAvbryteMeldekortBehandling.MåVæreUnderBehandling.left()
         }
-        require(this.saksbehandler == null || this.saksbehandler == avbruttAv.navIdent) {
+        require(this.saksbehandler == avbruttAv.navIdent) {
             return KanIkkeAvbryteMeldekortBehandling.MåVæreSaksbehandlerForMeldekortet.left()
         }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRoute.kt
@@ -68,7 +68,7 @@ fun Route.avbrytMeldekortBehandlingRoute(
 
                                 call.respond(
                                     status = HttpStatusCode.OK,
-                                    it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.IKKE_GODKJENT),
+                                    it.toMeldekortBehandlingDTO(UtbetalingsstatusDTO.AVBRUTT),
                                 )
                             },
                         )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeDTO.kt
@@ -21,6 +21,7 @@ data class MeldeperiodeKjedeDTO(
     val meldekortBehandlinger: List<MeldekortBehandlingDTO>,
     val brukersMeldekort: BrukersMeldekortDTO?,
     val korrigeringFraTidligerePeriode: MeldeperiodeKorrigeringDTO?,
+    val avbrutteMeldekortBehandlinger: List<MeldekortBehandlingDTO>,
 )
 
 fun Sak.toMeldeperiodeKjedeDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock): MeldeperiodeKjedeDTO {
@@ -61,6 +62,13 @@ fun Sak.toMeldeperiodeKjedeDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock): Meld
             },
         brukersMeldekort = brukersMeldekort ?.toBrukersMeldekortDTO(),
         korrigeringFraTidligerePeriode = korrigering,
+        avbrutteMeldekortBehandlinger = this.meldekortBehandlinger
+            .hentAvbrutteMeldekortBehandlingerForKjede(meldeperiodeKjede.kjedeId)
+            .map {
+                it.toMeldekortBehandlingDTO(
+                    UtbetalingsstatusDTO.IKKE_GODKJENT,
+                )
+            },
     )
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/MeldeperiodeKjedeDTO.kt
@@ -66,7 +66,7 @@ fun Sak.toMeldeperiodeKjedeDTO(kjedeId: MeldeperiodeKjedeId, clock: Clock): Meld
             .hentAvbrutteMeldekortBehandlingerForKjede(meldeperiodeKjede.kjedeId)
             .map {
                 it.toMeldekortBehandlingDTO(
-                    UtbetalingsstatusDTO.IKKE_GODKJENT,
+                    UtbetalingsstatusDTO.AVBRUTT,
                 )
             },
     )

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/UtbetalingsstatusDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/UtbetalingsstatusDTO.kt
@@ -23,6 +23,8 @@ enum class UtbetalingsstatusDTO {
 
     /** Kvitteringen fra oppdrag hadde en feil-status. I disse tilfellene må sannsynligvis helved eller en utvikler i fagsystemet følge opp. */
     FEILET_MOT_OPPDRAG,
+
+    AVBRUTT,
 }
 
 fun Utbetalingsstatus?.toUtbetalingsstatusDTO(): UtbetalingsstatusDTO {
@@ -32,6 +34,7 @@ fun Utbetalingsstatus?.toUtbetalingsstatusDTO(): UtbetalingsstatusDTO {
         Utbetalingsstatus.FeiletMotOppdrag -> UtbetalingsstatusDTO.FEILET_MOT_OPPDRAG
         Utbetalingsstatus.Ok -> UtbetalingsstatusDTO.OK
         Utbetalingsstatus.OkUtenUtbetaling -> UtbetalingsstatusDTO.OK_UTEN_UTBETALING
+        Utbetalingsstatus.Avbrutt -> UtbetalingsstatusDTO.AVBRUTT
         null -> UtbetalingsstatusDTO.IKKE_SENDT_TIL_HELVED
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/Sak.kt
@@ -4,7 +4,6 @@ import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
-import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeId
 import no.nav.tiltakspenger.libs.meldekort.MeldeperiodeKjedeId
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.libs.periodisering.Periodisering
@@ -65,12 +64,6 @@ data class Sak(
 
     fun hentMeldekortBehandling(meldekortId: MeldekortId): MeldekortBehandling? {
         return meldekortBehandlinger.hentMeldekortBehandling(meldekortId)
-    }
-
-    /** Flere behandlinger kan være knyttet til samme versjon av meldeperioden. */
-    @Suppress("unused")
-    fun hentMeldekortBehandlingerForMeldeperiode(meldeperiodeId: MeldeperiodeId): List<MeldekortBehandling> {
-        return meldekortBehandlinger.hentMeldekortBehandlingerForMeldeperiode(meldeperiodeId)
     }
 
     fun hentSisteMeldekortBehandlingForKjede(id: MeldeperiodeKjedeId): MeldekortBehandling? {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsstatus.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/domene/Utbetalingsstatus.kt
@@ -21,6 +21,8 @@ enum class Utbetalingsstatus {
     /** Ferdigstilt uten å ha blitt sendt til økonomisystemet pga. at det ikke er noe å utbetale */
     OkUtenUtbetaling,
 
+    Avbrutt,
+
     ;
 
     fun erOK(): Boolean {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/infra/repo/UtbetalingsstatusDbType.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/utbetaling/infra/repo/UtbetalingsstatusDbType.kt
@@ -9,6 +9,7 @@ fun Utbetalingsstatus.toDbType(): String {
         Utbetalingsstatus.FeiletMotOppdrag -> "FEILET_MOT_OPPDRAG"
         Utbetalingsstatus.Ok -> "OK"
         Utbetalingsstatus.OkUtenUtbetaling -> "OK_UTEN_UTBETALING"
+        Utbetalingsstatus.Avbrutt -> "AVBRUTT"
     }
 }
 
@@ -19,6 +20,7 @@ fun String?.toUtbetalingsstatus(): Utbetalingsstatus? {
         "FEILET_MOT_OPPDRAG" -> Utbetalingsstatus.FeiletMotOppdrag
         "OK" -> Utbetalingsstatus.Ok
         "OK_UTEN_UTBETALING" -> Utbetalingsstatus.OkUtenUtbetaling
+        "AVBRUTT" -> Utbetalingsstatus.Avbrutt
         null -> null
         else -> throw IllegalArgumentException("Ugyldig utbetalingsstatus: $this")
     }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRouteTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/AvbrytMeldekortBehandlingRouteTest.kt
@@ -66,6 +66,10 @@ class AvbrytMeldekortBehandlingRouteTest {
                     oppdatertMeldekortbehandling?.avbrutt?.saksbehandler shouldBe saksbehandlerIdent
                     oppdatertMeldekortbehandling?.avbrutt?.tidspunkt?.toLocalDate() shouldBe LocalDate.now()
                     oppdatertMeldekortbehandling?.avbrutt?.begrunnelse shouldBe begrunnelse
+
+                    val oppdatertSak = tac.sakContext.sakRepo.hentForSakId(sak.id)!!
+                    oppdatertSak.meldekortBehandlinger.ikkeAvbrutteMeldekortBehandlinger shouldBe emptyList()
+                    oppdatertSak.meldekortBehandlinger.avbrutteMeldekortBehandlinger.size shouldBe 1
                 }
             }
         }


### PR DESCRIPTION
Avbrutte behandlinger skal ikke være en del av resten av meldekortbehandlingene og skal ikke påvirke videre behandling, så de må filtreres ut der vi bruker meldekortbehandlingene. De skal derimot vises i frontend, så vi må inkludere dem i responsen. 

https://trello.com/c/XU9ti14p/1461-mulig-for-saksbehandler-%C3%A5-avslutte-manuell-meldekortbehandling