### PR TITLE
1409 fjerner tegn som kan brekke pdf-generering fra input

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/OppdaterBegrunnelseVilkårsvurderingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/OppdaterBegrunnelseVilkårsvurderingRoute.kt
@@ -7,6 +7,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
 import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.BegrunnelseVilkårsvurdering
@@ -20,7 +21,7 @@ import no.nav.tiltakspenger.saksbehandling.infra.repo.withSakId
 private data class BegrunnelseBody(
     val begrunnelse: String,
 ) {
-    fun toDomain() = BegrunnelseVilkårsvurdering(begrunnelse)
+    fun toDomain() = BegrunnelseVilkårsvurdering(saniter(begrunnelse))
 }
 
 fun Route.oppdaterBegrunnelseVilkårsvurderingRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendBehandlingTilBeslutningRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendBehandlingTilBeslutningRoute.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.libs.ktor.common.ErrorJson
 import no.nav.tiltakspenger.libs.periodisering.PeriodeDTO
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
@@ -57,8 +58,8 @@ private data class SendTilBeslutningBody(
             behandlingId = behandlingId,
             saksbehandler = saksbehandler,
             correlationId = correlationId,
-            fritekstTilVedtaksbrev = fritekstTilVedtaksbrev?.let { FritekstTilVedtaksbrev(it) },
-            begrunnelseVilkårsvurdering = begrunnelseVilkårsvurdering?.let { BegrunnelseVilkårsvurdering(it) },
+            fritekstTilVedtaksbrev = fritekstTilVedtaksbrev?.let { FritekstTilVedtaksbrev(saniter(it)) },
+            begrunnelseVilkårsvurdering = begrunnelseVilkårsvurdering?.let { BegrunnelseVilkårsvurdering(saniter(it)) },
             behandlingsperiode = behandlingsperiode,
             barnetillegg = barnetillegg?.tilBarnetillegg(behandlingsperiode),
             tiltaksdeltakelser = valgteTiltaksdeltakelser.map {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendRevurderingTilBeslutningRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/SendRevurderingTilBeslutningRoute.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.BegrunnelseVilkårsvurdering
@@ -55,8 +56,8 @@ private data class SendRevurderingTilBeslutningBody(
             saksbehandler = saksbehandler,
             correlationId = correlationId,
             stansDato = stansDato,
-            begrunnelse = BegrunnelseVilkårsvurdering(begrunnelse),
-            fritekstTilVedtaksbrev = fritekstTilVedtaksbrev?.let { FritekstTilVedtaksbrev(it) },
+            begrunnelse = BegrunnelseVilkårsvurdering(saniter(begrunnelse)),
+            fritekstTilVedtaksbrev = fritekstTilVedtaksbrev?.let { FritekstTilVedtaksbrev(saniter(it)) },
             valgteHjemler = valgteHjemler?.map { it.valgtHjemmelForStans() } ?: emptyList(),
         )
     }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/barnetillegg/BarnetilleggDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/barnetillegg/BarnetilleggDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.saksbehandling.behandling.infra.route.barnetillegg
 
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.libs.periodisering.Periode
 import no.nav.tiltakspenger.libs.periodisering.PeriodeDTO
 import no.nav.tiltakspenger.libs.periodisering.toDTO
@@ -13,7 +14,7 @@ internal data class BarnetilleggDTO(
     val begrunnelse: String?,
 ) {
     fun tilBarnetillegg(virkningsperiode: Periode?): Barnetillegg = Barnetillegg.periodiserOgFyllUtHullMed0(
-        begrunnelse = begrunnelse?.let { (BegrunnelseVilkårsvurdering(it)) },
+        begrunnelse = begrunnelse?.let { (BegrunnelseVilkårsvurdering(saniter(it))) },
         perioder = perioder.map { Pair(it.periode.toDomain(), AntallBarn(it.antallBarn)) },
         virkningsperiode = virkningsperiode,
     )
@@ -31,7 +32,7 @@ internal fun Barnetillegg.toBarnetilleggDTO(): BarnetilleggDTO = BarnetilleggDTO
             periode = it.periode.toDTO(),
         )
     },
-    begrunnelse = begrunnelse?.verdi,
+    begrunnelse = begrunnelse?.verdi?.let { saniter(it) },
 )
 
 internal fun List<BarnetilleggPeriodeDTO>.tilPeriodisering(virkningsperiode: Periode?) =

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/barnetillegg/OppdaterBarnetilleggRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/barnetillegg/OppdaterBarnetilleggRoute.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.barnetillegg.AntallBarn
@@ -34,7 +35,7 @@ private fun BarnetilleggDTO.toDomain(
         behandlingId = behandlingId,
         correlationId = correlationId,
         saksbehandler = saksbehandler,
-        begrunnelse = begrunnelse?.let { BegrunnelseVilkårsvurdering(it) },
+        begrunnelse = begrunnelse?.let { BegrunnelseVilkårsvurdering(saniter(it)) },
         perioder = perioder.map {
             Pair(it.periode.toDomain(), AntallBarn(it.antallBarn))
         },

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/brev/ForhåndsvisVedtaksbrevRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/brev/ForhåndsvisVedtaksbrevRoute.kt
@@ -11,6 +11,7 @@ import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.libs.periodisering.PeriodeDTO
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
@@ -46,7 +47,7 @@ internal data class ForhåndsvisBehandlingBody(
         val virkningsperiode = virkningsperiode?.toDomain()
 
         return ForhåndsvisVedtaksbrevKommando(
-            fritekstTilVedtaksbrev = FritekstTilVedtaksbrev(fritekst),
+            fritekstTilVedtaksbrev = FritekstTilVedtaksbrev(saniter(fritekst)),
             sakId = sakId,
             behandlingId = behandlingId,
             correlationId = correlationId,

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/brev/OppdaterFritekstRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/route/brev/OppdaterFritekstRoute.kt
@@ -7,6 +7,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
 import no.nav.tiltakspenger.libs.auth.core.TokenService
 import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
 import no.nav.tiltakspenger.saksbehandling.behandling.domene.FritekstTilVedtaksbrev
@@ -20,7 +21,7 @@ import no.nav.tiltakspenger.saksbehandling.infra.repo.withSakId
 private data class FritekstBody(
     val fritekst: String,
 ) {
-    fun toDomain() = FritekstTilVedtaksbrev(fritekst)
+    fun toDomain() = FritekstTilVedtaksbrev(saniter(fritekst))
 }
 
 fun Route.oppdaterFritekstTilVedtaksbrevRoute(

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/OppdaterMeldekortDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/OppdaterMeldekortDTO.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.OppdaterMeldekortKommando
 import java.time.LocalDate
@@ -37,7 +38,7 @@ data class OppdaterMeldekortDTO(
                 }.toNonEmptyListOrNull()!!,
             ),
             meldekortId = meldekortId,
-            begrunnelse = begrunnelse?.let { MeldekortBehandlingBegrunnelse(verdi = it) },
+            begrunnelse = begrunnelse?.let { MeldekortBehandlingBegrunnelse(verdi = saniter(it)) },
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/SendMeldekortTilBeslutterDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/meldekort/infra/route/dto/SendMeldekortTilBeslutterDTO.kt
@@ -5,6 +5,7 @@ import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.MeldekortId
 import no.nav.tiltakspenger.libs.common.SakId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.MeldekortBehandlingBegrunnelse
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.OppdaterMeldekortKommando
 import no.nav.tiltakspenger.saksbehandling.meldekort.domene.SendMeldekortTilBeslutterKommando
@@ -44,7 +45,7 @@ data class SendMeldekortTilBeslutterDTO(
                 )
             },
             meldekortId = meldekortId,
-            begrunnelse = begrunnelse?.let { MeldekortBehandlingBegrunnelse(verdi = it) },
+            begrunnelse = begrunnelse?.let { MeldekortBehandlingBegrunnelse(verdi = saniter(it)) },
         )
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/AvbrytSøknadOgBehandlingRoute.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/sak/infra/routes/AvbrytSøknadOgBehandlingRoute.kt
@@ -10,6 +10,7 @@ import no.nav.tiltakspenger.libs.auth.ktor.withSaksbehandler
 import no.nav.tiltakspenger.libs.common.BehandlingId
 import no.nav.tiltakspenger.libs.common.CorrelationId
 import no.nav.tiltakspenger.libs.common.Saksbehandler
+import no.nav.tiltakspenger.libs.common.SaniterStringForPdfgen.saniter
 import no.nav.tiltakspenger.libs.common.SøknadId
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditLogEvent
 import no.nav.tiltakspenger.saksbehandling.auditlog.AuditService
@@ -82,7 +83,7 @@ data class AvsluttSøknadOgBehandlingBody(
             behandlingId = behandlingId?.let { BehandlingId.fromString(it) },
             avsluttetAv = avsluttetAv,
             correlationId = correlationId,
-            begrunnelse = begrunnelse,
+            begrunnelse = saniter(begrunnelse),
 
         )
     }


### PR DESCRIPTION
https://trello.com/c/zDmTAbXR/1409-fjerne-rare-tegn-fra-fritekstfelter

(jeg har droppet dette for de tekstene som kun brukes i kommunikasjon mellom saksbehandler og beslutter og som ikke er med i pdf-en, f.eks. begrunnelse for underkjenn)