### PR TITLE
1598 oppretter oppgave for ny søknad hvis bruker har kode 6

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/setup/BehandlingOgVedtakContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/infra/setup/BehandlingOgVedtakContext.kt
@@ -8,6 +8,7 @@ import no.nav.tiltakspenger.saksbehandling.behandling.ports.GenererVedtaksbrevFo
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.GenererVedtaksbrevForInnvilgelseKlient
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.GenererVedtaksbrevForStansKlient
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.JournalførRammevedtaksbrevKlient
+import no.nav.tiltakspenger.saksbehandling.behandling.ports.OppgaveKlient
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.RammevedtakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkSakRepo
 import no.nav.tiltakspenger.saksbehandling.behandling.ports.StatistikkStønadRepo
@@ -35,10 +36,10 @@ import no.nav.tiltakspenger.saksbehandling.distribusjon.Dokumentdistribusjonskli
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldekortBehandlingRepo
 import no.nav.tiltakspenger.saksbehandling.meldekort.ports.MeldeperiodeRepo
 import no.nav.tiltakspenger.saksbehandling.oppfølgingsenhet.NavkontorService
+import no.nav.tiltakspenger.saksbehandling.person.PersonKlient
 import no.nav.tiltakspenger.saksbehandling.saksbehandler.NavIdentClient
 import no.nav.tiltakspenger.saksbehandling.statistikk.behandling.StatistikkSakService
 import no.nav.tiltakspenger.saksbehandling.tiltaksdeltagelse.infra.TiltaksdeltagelseKlient
-import no.nav.tiltakspenger.saksbehandling.utbetaling.ports.MeldekortVedtakRepo
 import no.nav.tiltakspenger.saksbehandling.utbetaling.service.SimulerService
 import no.nav.tiltakspenger.saksbehandling.vedtak.infra.repo.RammevedtakPostgresRepo
 import no.nav.tiltakspenger.saksbehandling.ytelser.infra.http.SokosUtbetaldataClient
@@ -66,8 +67,9 @@ open class BehandlingOgVedtakContext(
     clock: Clock,
     sokosUtbetaldataClient: SokosUtbetaldataClient,
     navkontorService: NavkontorService,
-    meldekortVedtakRepo: MeldekortVedtakRepo,
     simulerService: SimulerService,
+    personKlient: PersonKlient,
+    oppgaveKlient: OppgaveKlient,
 ) {
     open val rammevedtakRepo: RammevedtakRepo by lazy { RammevedtakPostgresRepo(sessionFactory as PostgresSessionFactory) }
     open val behandlingRepo: BehandlingRepo by lazy {
@@ -94,6 +96,8 @@ open class BehandlingOgVedtakContext(
             hentSaksopplysingerService = hentSaksopplysingerService,
             clock = clock,
             statistikkSakService = statistikkSakService,
+            personKlient = personKlient,
+            oppgaveKlient = oppgaveKlient,
         )
     }
     val delautomatiskBehandlingService: DelautomatiskBehandlingService by lazy {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/OppgaveKlient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/behandling/ports/OppgaveKlient.kt
@@ -21,4 +21,5 @@ enum class Oppgavebehov {
     NYTT_MELDEKORT,
     FATT_BARN,
     DOED,
+    NY_SOKNAD,
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/infra/setup/ApplicationContext.kt
@@ -293,8 +293,9 @@ open class ApplicationContext(
             statistikkSakService = statistikkContext.statistikkSakService,
             sokosUtbetaldataClient = sokosUtbetaldataClient,
             navkontorService = navkontorService,
-            meldekortVedtakRepo = utbetalingContext.meldekortVedtakRepo,
             simulerService = utbetalingContext.simulerService,
+            personKlient = personContext.personKlient,
+            oppgaveKlient = oppgaveKlient,
         )
     }
     open val benkOversiktContext by lazy {

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/oppgave/infra/OppgaveDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/oppgave/infra/OppgaveDto.kt
@@ -65,6 +65,17 @@ data class OpprettOppgaveRequest(
             behandlesAvApplikasjon = BEHANDLES_AV_APPLIKASJON,
             oppgavetype = OppgaveType.OPPGAVETYPE_VURDER_HENVENDELSE.value,
         )
+
+        fun opprettOppgaveRequestForSoknad(
+            fnr: Fnr,
+            journalpostId: JournalpostId,
+        ) = OpprettOppgaveRequest(
+            personident = fnr.verdi,
+            journalpostId = journalpostId.toString(),
+            beskrivelse = "Ny søknad om tiltakspenger. Behandles i ny løsning.",
+            behandlesAvApplikasjon = null,
+            oppgavetype = OppgaveType.OPPGAVETYPE_BEHANDLE_SAK.value,
+        )
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/oppgave/infra/OppgaveHttpClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/oppgave/infra/OppgaveHttpClient.kt
@@ -48,6 +48,12 @@ class OppgaveHttpClient(
                     journalpostId = journalpostId,
                 )
             }
+            Oppgavebehov.NY_SOKNAD -> {
+                OpprettOppgaveRequest.opprettOppgaveRequestForSoknad(
+                    fnr = fnr,
+                    journalpostId = journalpostId,
+                )
+            }
 
             else -> {
                 logger.error { "Ukjent oppgavebehov for oppgave med journalpost: ${oppgavebehov.name}" }

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/LocalApplicationContext.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/LocalApplicationContext.kt
@@ -210,8 +210,9 @@ class LocalApplicationContext(
             statistikkSakService = statistikkContext.statistikkSakService,
             sokosUtbetaldataClient = sokosUtbetaldataClient,
             navkontorService = navkontorService,
-            meldekortVedtakRepo = utbetalingContext.meldekortVedtakRepo,
             simulerService = utbetalingContext.simulerService,
+            personKlient = personContext.personKlient,
+            oppgaveKlient = oppgaveKlient,
         ) {}
     }
     override val utbetalingContext by lazy {

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/common/TestApplicationContext.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/common/TestApplicationContext.kt
@@ -227,8 +227,9 @@ class TestApplicationContext(
             statistikkSakService = statistikkContext.statistikkSakService,
             sokosUtbetaldataClient = sokosUtbetaldataFakeClient,
             navkontorService = navkontorService,
-            meldekortVedtakRepo = utbetalingContext.meldekortVedtakRepo,
             simulerService = utbetalingContext.simulerService,
+            personKlient = personContext.personKlient,
+            oppgaveKlient = oppgaveKlient,
         ) {
             override val rammevedtakRepo = rammevedtakFakeRepo
             override val behandlingRepo = behandlingFakeRepo


### PR DESCRIPTION
Oppretter oppgave hvis det kommer en søknad på en kode 6-bruker. Opprettingen av oppgave har duplikatsjekk, så hvis den finnes fra før opprettes det ikke flere. Jeg har valgt å la saksbehandler ferdigstille oppgaven i gosys selv i stedet for å lage logikk for å ta vare på oppgaveid og ferdigstille automatisk siden dette vil gjelde forsvinnende få saker. 

https://trello.com/c/YYq9ini8/1598-opprette-oppgaver-for-manuell-behandling-hvis-bruker-er-kode-6