### PR TITLE
1412 deler avslagsvedtak, stans/avslagsgrunner og oppdaterer format

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/datadeling/infra/client/DatadelingVedtakJson.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/datadeling/infra/client/DatadelingVedtakJson.kt
@@ -2,7 +2,13 @@ package no.nav.tiltakspenger.saksbehandling.datadeling.infra.client
 
 import no.nav.tiltakspenger.libs.json.serialize
 import no.nav.tiltakspenger.saksbehandling.barnetillegg.Barnetillegg
-import no.nav.tiltakspenger.saksbehandling.behandling.domene.maksAntallDager
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Avslagsgrunnlag
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Revurdering
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.RevurderingResultat
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.Søknadsbehandling
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.SøknadsbehandlingResultat
+import no.nav.tiltakspenger.saksbehandling.behandling.domene.ValgtHjemmelForStans
+import no.nav.tiltakspenger.saksbehandling.datadeling.infra.client.DatadelingVedtakJson.ValgtHjemmelHarIkkeRettighet
 import no.nav.tiltakspenger.saksbehandling.vedtak.Rammevedtak
 import no.nav.tiltakspenger.saksbehandling.vedtak.Vedtakstype
 import java.time.LocalDate
@@ -13,11 +19,11 @@ private data class DatadelingVedtakJson(
     val saksnummer: String,
     val fom: LocalDate,
     val tom: LocalDate,
-    val antallDagerPerMeldeperiode: Int,
     val rettighet: String,
     val fnr: String,
     val opprettet: String,
     val barnetillegg: Barnetillegg?,
+    val valgteHjemlerHarIkkeRettighet: List<String>?,
 ) {
     data class Barnetillegg(
         val perioder: List<BarnetilleggPeriode>,
@@ -32,6 +38,18 @@ private data class DatadelingVedtakJson(
             val tilOgMed: LocalDate,
         )
     }
+
+    enum class ValgtHjemmelHarIkkeRettighet {
+        DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK,
+        ALDER,
+        LIVSOPPHOLDSYTELSER,
+        KVALIFISERINGSPROGRAMMET,
+        INTRODUKSJONSPROGRAMMET,
+        LONN_FRA_TILTAKSARRANGOR,
+        LONN_FRA_ANDRE,
+        INSTITUSJONSOPPHOLD,
+        FREMMET_FOR_SENT,
+    }
 }
 
 fun Rammevedtak.toDatadelingJson(): String {
@@ -41,8 +59,6 @@ fun Rammevedtak.toDatadelingJson(): String {
         saksnummer = this.saksnummer.verdi,
         fom = periode.fraOgMed,
         tom = periode.tilOgMed,
-        // TODO abn: Ta hensyn til periodisering istedenfor bare maks. Evt fjern dersom denne ikke deles med noen.
-        antallDagerPerMeldeperiode = antallDagerPerMeldeperiode.maksAntallDager(),
         rettighet = when (this.vedtakstype) {
             Vedtakstype.INNVILGELSE -> {
                 if (barnetillegg?.harBarnetillegg == true) {
@@ -52,13 +68,13 @@ fun Rammevedtak.toDatadelingJson(): String {
                 }
             }
 
-            Vedtakstype.STANS -> "INGENTING"
-            // Denne skal helst ikke bli truffet da servicen ikke skal prøve å sende for avlsag
-            Vedtakstype.AVSLAG -> throw IllegalArgumentException("Vi dropper sende noe til datadeling nå for avslag")
+            Vedtakstype.STANS -> "STANS"
+            Vedtakstype.AVSLAG -> "AVSLAG"
         },
         fnr = fnr.verdi,
         opprettet = opprettet.toString(),
         barnetillegg = barnetillegg?.toDatadelingBarnetillegg(),
+        valgteHjemlerHarIkkeRettighet = this.toValgteHjemlerHarIkkeRettighetListe(),
     ).let { serialize(it) }
 }
 
@@ -77,3 +93,42 @@ private fun Barnetillegg.toDatadelingBarnetillegg(): DatadelingVedtakJson.Barnet
 } else {
     null
 }
+
+private fun Rammevedtak.toValgteHjemlerHarIkkeRettighetListe(): List<String>? {
+    return when (this.vedtakstype) {
+        Vedtakstype.INNVILGELSE -> null
+        Vedtakstype.STANS -> (this.behandling as Revurdering).toValgteHjemlerHarIkkeRettighetListe()
+        Vedtakstype.AVSLAG -> (this.behandling as Søknadsbehandling).toValgteHjemlerHarIkkeRettighetListe()
+    }
+}
+
+private fun Revurdering.toValgteHjemlerHarIkkeRettighetListe() =
+    (this.resultat as RevurderingResultat.Stans).valgtHjemmel.map { it.toValgtHjemmelHarIkkeRettighetString() }
+
+private fun Søknadsbehandling.toValgteHjemlerHarIkkeRettighetListe() =
+    (this.resultat as SøknadsbehandlingResultat.Avslag).avslagsgrunner.map { it.toValgtHjemmelHarIkkeRettighetString() }
+
+private fun ValgtHjemmelForStans.toValgtHjemmelHarIkkeRettighetString() =
+    when (this) {
+        ValgtHjemmelForStans.DeltarIkkePåArbeidsmarkedstiltak -> ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK.name
+        ValgtHjemmelForStans.Alder -> ValgtHjemmelHarIkkeRettighet.ALDER.name
+        ValgtHjemmelForStans.Institusjonsopphold -> ValgtHjemmelHarIkkeRettighet.INSTITUSJONSOPPHOLD.name
+        ValgtHjemmelForStans.Introduksjonsprogrammet -> ValgtHjemmelHarIkkeRettighet.INTRODUKSJONSPROGRAMMET.name
+        ValgtHjemmelForStans.Kvalifiseringsprogrammet -> ValgtHjemmelHarIkkeRettighet.KVALIFISERINGSPROGRAMMET.name
+        ValgtHjemmelForStans.Livsoppholdytelser -> ValgtHjemmelHarIkkeRettighet.LIVSOPPHOLDSYTELSER.name
+        ValgtHjemmelForStans.LønnFraAndre -> ValgtHjemmelHarIkkeRettighet.LONN_FRA_ANDRE.name
+        ValgtHjemmelForStans.LønnFraTiltaksarrangør -> ValgtHjemmelHarIkkeRettighet.LONN_FRA_TILTAKSARRANGOR.name
+    }
+
+private fun Avslagsgrunnlag.toValgtHjemmelHarIkkeRettighetString() =
+    when (this) {
+        Avslagsgrunnlag.DeltarIkkePåArbeidsmarkedstiltak -> ValgtHjemmelHarIkkeRettighet.DELTAR_IKKE_PA_ARBEIDSMARKEDSTILTAK.name
+        Avslagsgrunnlag.Alder -> ValgtHjemmelHarIkkeRettighet.ALDER.name
+        Avslagsgrunnlag.FremmetForSent -> ValgtHjemmelHarIkkeRettighet.FREMMET_FOR_SENT.name
+        Avslagsgrunnlag.Institusjonsopphold -> ValgtHjemmelHarIkkeRettighet.INSTITUSJONSOPPHOLD.name
+        Avslagsgrunnlag.Introduksjonsprogrammet -> ValgtHjemmelHarIkkeRettighet.INTRODUKSJONSPROGRAMMET.name
+        Avslagsgrunnlag.Kvalifiseringsprogrammet -> ValgtHjemmelHarIkkeRettighet.KVALIFISERINGSPROGRAMMET.name
+        Avslagsgrunnlag.Livsoppholdytelser -> ValgtHjemmelHarIkkeRettighet.LIVSOPPHOLDSYTELSER.name
+        Avslagsgrunnlag.LønnFraAndre -> ValgtHjemmelHarIkkeRettighet.LONN_FRA_ANDRE.name
+        Avslagsgrunnlag.LønnFraTiltaksarrangør -> ValgtHjemmelHarIkkeRettighet.LONN_FRA_TILTAKSARRANGOR.name
+    }

--- a/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/vedtak/infra/repo/RammevedtakPostgresRepo.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/saksbehandling/vedtak/infra/repo/RammevedtakPostgresRepo.kt
@@ -193,7 +193,7 @@ class RammevedtakPostgresRepo(
                     """
                     select *
                     from rammevedtak
-                    where sendt_til_datadeling is null and vedtakstype != 'AVSLAG'
+                    where sendt_til_datadeling is null
                     order by opprettet
                     limit $limit
                     """.trimIndent(),

--- a/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/vedtak/infra/repo/RammevedtakPostgresRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/saksbehandling/vedtak/infra/repo/RammevedtakPostgresRepoTest.kt
@@ -24,10 +24,10 @@ class RammevedtakPostgresRepoTest {
     }
 
     @Test
-    fun `henter ikke avslagsvedtak for datadeling`() {
+    fun `henter avslagsvedtak for datadeling`() {
         withMigratedDb(runIsolated = true) { testDataHelper ->
-            testDataHelper.persisterRammevedtakAvslag()
-            testDataHelper.vedtakRepo.hentRammevedtakTilDatadeling() shouldBe emptyList()
+            val (_, rammevedtak) = testDataHelper.persisterRammevedtakAvslag()
+            testDataHelper.vedtakRepo.hentRammevedtakTilDatadeling() shouldBe listOf(rammevedtak)
         }
     }
 


### PR DESCRIPTION
Denne vil medføre at vi deler alle avslagsvedtak med tiltakspenger-datadeling når den deployes. For å få oppdatert tiltakspenger-datadeling med stansgrunner må stans-vedtakene resendes (det tenkte jeg å gjøre manuelt siden det ikke er så mange). 

https://trello.com/c/A9xGZY5O/1412-nks-salesforce-trenger-data-om-tiltakspengevedtak-og-meldekort